### PR TITLE
Enable from_samples() for regular builds

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -191,7 +191,6 @@ const fn convert_open_err(e: &SndFileError) -> SourceError {
 
 impl PreloadedSignal {
     /// Constructs `PreloadedSignal` from samples.
-    #[cfg(test)]
     pub fn from_samples(
         samples: &[i32],
         channels: usize,


### PR DESCRIPTION
This was previously only available during test, but is now free for general use. Closes #6 