### PR TITLE
Fix a bug introduced in 6e96049.

### DIFF
--- a/flacenc-bin/src/main.rs
+++ b/flacenc-bin/src/main.rs
@@ -89,12 +89,6 @@ struct Args {
 #[allow(clippy::expect_used)]
 fn write_stream<F: Write>(stream: &Stream, file: &mut F) {
     eprintln!("{} bits to be written", stream.count_bits());
-    // let mut bv: BitVec<u8, Msb0> = BitVec::with_capacity(stream.count_bits());
-    // stream.write(&mut bv).expect("Bitstream formatting failed.");
-    // let mut writer = BufWriter::new(file);
-    // writer
-    //     .write_all(bv.as_raw_slice())
-    //     .expect("File write failed.");
     let mut bv = flacenc::bitsink::ByteVec::new();
     stream.write(&mut bv).expect("Bitstream formatting failed.");
     let mut writer = BufWriter::new(file);

--- a/report/report.md
+++ b/report/report.md
@@ -21,14 +21,14 @@ Sources used: wikimedia.i_love_you_california, wikimedia.winter_kiss, wikimedia.
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 257.7849467896516
-    - opt8: 251.1527880915968
-    - opt5: 501.03630516078925
+    - opt8lax: 257.9766459270744
+    - opt8: 256.2010819290685
+    - opt5: 477.0431609974724
 
   - Ours
-    - default: 52.7637956617831
-    - dmse: 52.35116821103436
-    - bsbs: 52.11728073283382
-    - mae: 52.33861337278744
+    - default: 49.95345620740272
+    - dmse: 49.862356799167635
+    - bsbs: 49.19340838451352
+    - mae: 49.70608853734756
 
 

--- a/testtool/reporter.py
+++ b/testtool/reporter.py
@@ -230,9 +230,7 @@ def main():
     test_run_results = run_encoder(
         inputs,
         testenc_out_root,
-        str(
-            project_root / "flacenc-bin" / "target" / "release" / "flacenc-exp"
-        ),
+        str(project_root / "flacenc-bin" / "target" / "release" / "flacenc"),
         TEST_ENCODER_OPTS,
     )
 


### PR DESCRIPTION
`flacenc-exp` binary is no longer produced by cargo, but reporter script was still using it to produce the performance report.