### PR TITLE
Fix a bug that experimental wasn't enabled in CLI.

### DIFF
--- a/flacenc-bin/Cargo.toml
+++ b/flacenc-bin/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "3.1.8", features = ["derive"] }
-flacenc = { version = "0.1.1", path = ".." }
+flacenc = { version = "0.1.1", path = "..", features = ["experimental"] }
 hound = "3.5.0"
 pprof = { version = "0.12", features = ["flamegraph", "protobuf-codec"], optional = true }
 toml = "0.5"
@@ -30,4 +30,3 @@ toml = "0.5"
 
 [features]
 pprof = [ "dep:pprof" ]
-experimental = ["flacenc/experimental"]

--- a/flacenc-bin/src/main.rs
+++ b/flacenc-bin/src/main.rs
@@ -136,26 +136,16 @@ pub fn load_input_wav<P: AsRef<Path>>(
     ))
 }
 
-#[cfg(feature = "experimental")]
 fn run_encoder(
     encoder_config: &config::Encoder,
     source: source::PreloadedSignal,
 ) -> Result<Stream, SourceError> {
     if encoder_config.block_sizes.len() == 1 {
         let block_size = encoder_config.block_sizes[0];
-        coding::par_encode_with_fixed_block_size(&encoder_config, source, block_size)
+        coding::encode_with_fixed_block_size(encoder_config, source, block_size)
     } else {
-        coding::encode_with_multiple_block_sizes(&encoder_config, source)
+        coding::encode_with_multiple_block_sizes(encoder_config, source)
     }
-}
-
-#[cfg(not(feature = "experimental"))]
-fn run_encoder(
-    encoder_config: &config::Encoder,
-    source: source::PreloadedSignal,
-) -> Result<Stream, SourceError> {
-    let block_size = encoder_config.block_sizes[0];
-    coding::par_encode_with_fixed_block_size(encoder_config, source, block_size)
 }
 
 fn main_body(args: Args) -> Result<(), i32> {

--- a/report/report.md
+++ b/report/report.md
@@ -14,21 +14,21 @@ Sources used: wikimedia.i_love_you_california, wikimedia.winter_kiss, wikimedia.
 
   - Ours
     - default: 0.5443052357800366
-    - dmse: 0.5638071571209627
-    - bsbs: 0.5443052357800366
-    - mae: 0.5638071571209627
+    - dmse: 0.5418910269181569
+    - bsbs: 0.5435087256676912
+    - mae: 0.5374008633412148
 
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 259.46562087868097
-    - opt8: 260.0256186764421
-    - opt5: 489.021513867803
+    - opt8lax: 259.5363983239151
+    - opt8: 255.04180944185632
+    - opt5: 480.08948488664015
 
   - Ours
-    - default: 145.29642491541563
-    - dmse: 146.4336266528441
-    - bsbs: 146.17054810154346
-    - mae: 143.10456190634406
+    - default: 147.73177741587608
+    - dmse: 110.59936109083178
+    - bsbs: 6.6560855133273495
+    - mae: 32.21428513358941
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,14 @@ mae_optimization_steps = 2
                 signal.push(s[t]);
             }
         }
-        let config = toml::from_str(config).expect("config parsing error");
+        let mut config: config::Encoder = toml::from_str(config).expect("config parsing error");
+
+        if !cfg!(feature = "experimental") {
+            // disable experimental features
+            config.subframe_coding.qlpc.use_direct_mse = false;
+            config.subframe_coding.qlpc.mae_optimization_steps = 0;
+        }
+
         let source =
             source::PreloadedSignal::from_samples(&signal, channels, bits_per_sample, sample_rate);
 

--- a/src/lpc.rs
+++ b/src/lpc.rs
@@ -685,6 +685,16 @@ pub fn lpc_with_direct_mse(
     })
 }
 
+#[allow(clippy::module_name_repetitions)]
+#[cfg(not(feature = "experimental"))]
+pub fn lpc_with_direct_mse(
+    _signal: &[i32],
+    _window: &Window,
+    _lpc_order: usize,
+) -> heapless::Vec<f32, MAX_LPC_ORDER> {
+    unimplemented!("not built with \"experimental\" feature flag.")
+}
+
 /// Estimates LPC coefficients with IRLS-MAE method.
 #[allow(clippy::module_name_repetitions)]
 #[cfg(feature = "experimental")]
@@ -699,6 +709,17 @@ pub fn lpc_with_irls_mae(
             .borrow_mut()
             .lpc_with_irls_mae(signal, window, lpc_order, steps)
     })
+}
+
+#[allow(clippy::module_name_repetitions)]
+#[cfg(not(feature = "experimental"))]
+pub fn lpc_with_irls_mae(
+    _signal: &[i32],
+    _window: &Window,
+    _lpc_order: usize,
+    _steps: usize,
+) -> heapless::Vec<f32, MAX_LPC_ORDER> {
+    unimplemented!("not built with \"experimental\" feature flag.")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This commit also simplifies feature gating.
Now, declaration for experimental functions are aso in the non-experimental builds, but instead it emits "unimplemented" when it is called.