### PR TITLE
Minor optimization.

### DIFF
--- a/flacenc-bin/Cargo.toml
+++ b/flacenc-bin/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/yotarok/flacenc-rs/"
 debug = 1
 panic = "abort"
 lto = "fat"
+codegen-units = 1
 
 [[bin]]
 name = "flacenc"

--- a/report/report.md
+++ b/report/report.md
@@ -21,14 +21,14 @@ Sources used: wikimedia.i_love_you_california, wikimedia.winter_kiss, wikimedia.
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 255.3836084284399
-    - opt8: 256.6389900206891
-    - opt5: 493.1953626017115
+    - opt8lax: 258.8324501964389
+    - opt8: 255.37311996195788
+    - opt5: 497.2015031869035
 
   - Ours
-    - default: 269.09221608610744
-    - st: 94.99698177817307
-    - dmse: 163.21980486345106
-    - mae: 26.88273747979565
+    - default: 280.49915771421183
+    - st: 102.84285535481595
+    - dmse: 183.0220425392949
+    - mae: 40.46853900438779
 
 

--- a/src/rice.rs
+++ b/src/rice.rs
@@ -232,7 +232,8 @@ impl PrcParameterFinder {
             let next_bits = eval_partitions(&self.tables[0..nparts], &mut self.ps);
             if next_bits < min_bits {
                 min_bits = next_bits;
-                self.min_ps = self.ps.clone();
+                self.min_ps.clear();
+                self.min_ps.extend_from_slice(&self.ps);
                 min_order = partition_order;
             }
         }


### PR DESCRIPTION
This commit does:
1. set "codegen-units = 1" in Cargo.toml
2. change not to construct "Verbatim" component unless it's shown to be minimum.
3. change not to construct frames for unused stereo-coding candidates.
4. encode utf8 is changed to return heapless vec of bytes. This can save some BitSink operations because results of this function is always written aligned to byte boundaries.
5. count_bits are now inlined.
6. reallocation in min_ps field in PrcParameterFinder is eliminated.
7. Minor reordering of sub-functions in par-mode encoding for maximizing parallelism.