### PR TITLE
Change to use custom Source for flacenc-bin.

### DIFF
--- a/report/report.md
+++ b/report/report.md
@@ -21,14 +21,14 @@ Sources used: wikimedia.i_love_you_california, wikimedia.winter_kiss, wikimedia.
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 258.8324501964389
-    - opt8: 255.37311996195788
-    - opt5: 497.2015031869035
+    - opt8lax: 263.0515223440761
+    - opt8: 259.1675443841502
+    - opt5: 494.0462089319891
 
   - Ours
-    - default: 280.49915771421183
-    - st: 102.84285535481595
-    - dmse: 183.0220425392949
-    - mae: 40.46853900438779
+    - default: 311.5466700534162
+    - st: 102.46001430873105
+    - dmse: 192.25265039265963
+    - mae: 40.35315704283569
 
 


### PR DESCRIPTION
This is good for demonstrating how to customize source of encoder, and also good for performance in multi-thread mode (because, unlike pre-loaded signals, file I/O is done while other frames are being encoded.)