### PR TITLE
Short-cut format manipulations in MD5 computation.

### DIFF
--- a/flacenc-bin/src/main.rs
+++ b/flacenc-bin/src/main.rs
@@ -48,7 +48,6 @@
 use std::fmt::Debug;
 use std::fs::File;
 use std::io::BufReader;
-use std::io::BufWriter;
 use std::io::Read;
 use std::io::Write;
 use std::path::Path;
@@ -97,9 +96,7 @@ fn write_stream<F: Write>(stream: &Stream, file: &mut F) {
     eprintln!("{bits} bits to be written");
     let mut bv = flacenc::bitsink::ByteVec::with_capacity(bits);
     stream.write(&mut bv).expect("Bitstream formatting failed.");
-    let mut writer = BufWriter::new(file);
-    writer
-        .write_all(bv.as_byte_slice())
+    file.write_all(bv.as_byte_slice())
         .expect("Failed to write a bitstream to the file.");
 }
 
@@ -201,7 +198,7 @@ impl Source for HoundSource {
 
         dest.fill_from_interleaved(&self.buf);
         if !self.buf.is_empty() {
-            context.update(&self.buf, dest.size())?;
+            context.update_with_le_bytes(&self.bytebuf, dest.size())?;
         }
         Ok(self.buf.len() / self.channels())
     }

--- a/report/report.md
+++ b/report/report.md
@@ -21,14 +21,14 @@ Sources used: wikimedia.i_love_you_california, wikimedia.winter_kiss, wikimedia.
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 261.9955005423485
-    - opt8: 259.5267137767212
-    - opt5: 508.91301633056014
+    - opt8lax: 260.4038600372263
+    - opt8: 259.98664886414764
+    - opt5: 494.96912255280733
 
   - Ours
-    - default: 426.91237041715493
-    - st: 123.35203435319345
-    - dmse: 248.98706380401353
-    - mae: 32.63025782957665
+    - default: 495.01477830820414
+    - st: 132.16015908304058
+    - dmse: 258.7558643091015
+    - mae: 33.86630826748744
 
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -198,6 +198,30 @@ impl Context {
         Ok(())
     }
 
+    /// Updates the context with the read bytes.
+    ///
+    /// This function is a short-cut version of `update` that can be used when
+    /// `Source` already have a WAV-file-like sample buffer.
+    ///
+    /// # Errors
+    ///
+    /// This function currently does not return an error.
+    pub fn update_with_le_bytes(
+        &mut self,
+        packed_samples: &[u8],
+        block_size: usize,
+    ) -> Result<(), SourceError> {
+        self.md5.consume(packed_samples);
+        let block_byte_count = block_size * self.channels * self.bytes_per_sample;
+        if packed_samples.len() < block_byte_count {
+            self.md5
+                .consume(vec![0u8; block_byte_count - packed_samples.len()]);
+        }
+        self.sample_count += packed_samples.len() / self.channels / self.bytes_per_sample;
+        self.frame_count += 1;
+        Ok(())
+    }
+
     /// Returns the count of the last frame loaded.
     ///
     /// # Panics


### PR DESCRIPTION
This commit also disables unnecessary buffering in output writer.