### PR TITLE
Speed-up bytes_to_ints.

### DIFF
--- a/flacenc-bin/src/main.rs
+++ b/flacenc-bin/src/main.rs
@@ -103,10 +103,9 @@ fn write_stream<F: Write>(stream: &Stream, file: &mut F) {
 /// Converts a byte-sequence of little-endian integers to integers (i32).
 fn bytes_to_ints(bytes: &[u8], dest: &mut [i32], bytes_per_sample: usize) {
     let bitshift = bytes_per_sample * 8;
+    let pad = 4 - bytes_per_sample;
     for (vals, dest_p) in bytes.chunks(bytes_per_sample).zip(dest.iter_mut()) {
-        let mut bs = std::array::from_fn(|_n| 0);
-        bs[4 - bytes_per_sample..].copy_from_slice(vals);
-
+        let bs = std::array::from_fn(|n| if n < pad { 0 } else { vals[n - pad] });
         *dest_p = i32::from_le_bytes(bs) >> bitshift;
     }
 }

--- a/report/report.md
+++ b/report/report.md
@@ -21,14 +21,14 @@ Sources used: wikimedia.i_love_you_california, wikimedia.winter_kiss, wikimedia.
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 258.601753287338
-    - opt8: 263.7785770831825
-    - opt5: 506.7054949756316
+    - opt8lax: 257.61558589460105
+    - opt8: 254.6961583912233
+    - opt5: 492.08367247696924
 
   - Ours
-    - default: 486.20118677127033
-    - st: 153.62600133632637
-    - dmse: 263.6094344613446
-    - mae: 34.66000996779327
+    - default: 565.0427879962018
+    - st: 161.83595159414114
+    - dmse: 272.100217725058
+    - mae: 39.60950202411597
 
 


### PR DESCRIPTION
Found that the previous approach to use zero-clear and then copy_from_slice wasn't very efficient.