### PR TITLE
Update READMEs and flacenc-bin now uses mimalloc feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # flacenc-rs
 
 [![Build Status](https://github.com/yotarok/flacenc-rs/workflows/Unittest/badge.svg)](https://github.com/yotarok/flacenc-rs/actions)
+[![Crate](https://img.shields.io/crates/v/flacenc.svg)](https://crates.io/crates/flacenc)
 [![Documentation](https://docs.rs/flacenc/badge.svg)](https://docs.rs/flacenc)
 
 This crate provides some basic modules for building application customized FLAC
@@ -15,7 +16,7 @@ encoder compared to
 Add the following line to your `Cargo.toml`:
 
 ```toml
-flacenc = { version = "0.2", feature = ["fakesimd"] }
+flacenc = { version = "0.2.0", feature = ["fakesimd"] }
 ```
 
 This crate is intended to be, and primarily developed with
@@ -25,7 +26,7 @@ toolchain. If you are using a nightly toolchain, use this crate without
 `fakesimd` as follows:
 
 ```toml
-flacenc = "0.2"
+flacenc = "0.2.0"
 ```
 
 ## Examples
@@ -57,7 +58,7 @@ flac_stream.write(&mut sink);
 // Then, e.g. you can write it to a file.
 std::fs::write("/dev/null", sink.as_byte_slice());
 
-// or you can only get a specific frame.
+// or you can write only a specific frame.
 let mut sink = flacenc::bitsink::ByteSink::new();
 flac_stream.frame(0).unwrap().write(&mut sink);
 ```

--- a/flacenc-bin/Cargo.lock
+++ b/flacenc-bin/Cargo.lock
@@ -318,6 +318,7 @@ dependencies = [
  "crossbeam-channel",
  "heapless",
  "md5",
+ "mimalloc",
  "nalgebra",
  "num-traits",
  "seq-macro",
@@ -457,6 +458,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +518,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/flacenc-bin/Cargo.toml
+++ b/flacenc-bin/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
-flacenc = { version = "0.2.0", path = "..", features = ["experimental"] }
+flacenc = { version = "0.2.0", path = "..", features = ["experimental", "mimalloc"] }
 hound = "3.5.0"
 pprof = { version = "0.12", features = ["flamegraph", "protobuf-codec"], optional = true }
 toml = "0.5"

--- a/flacenc-bin/README.md
+++ b/flacenc-bin/README.md
@@ -2,15 +2,28 @@
 
 See [flacenc-rs](https://github.com/yotarok/flacenc-rs) for project overview.
 
-
 ## Usage
+
+To install (with using nightly rust):
+
+```bash
+rustup default nightly && cargo install flacenc-bin
+```
+
+Or, if you want to use stable channel:
+
+```bash
+cargo install flacenc-bin --features fakesimd
+```
+
+To encode a wav file:
 
 ```bash
 flacenc --output output.flac input.wav
 ```
 
-If you want to customize encoder behavior, you can specify an additional config
-toml file. To do so, first, you may generate the default config file by:
+If you want to customize the encoder behavior, you can specify an additional
+config toml file. To do so, first, you may generate the default config file by:
 
 ```bash
 flacenc --output output.flac --dump-config config.toml input.wav
@@ -21,4 +34,3 @@ Then, you can edit `config.toml` and do:
 ```bash
 flacenc --output output.flac --config config.toml input.wav
 ```
-

--- a/report/report.md
+++ b/report/report.md
@@ -22,15 +22,15 @@ Sources used: wikimedia.i_love_you_california, wikimedia.winter_kiss, wikimedia.
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 258.1894973828359
-    - opt8: 257.8985051092336
-    - opt5: 492.66456940888526
+    - opt8lax: 259.60679073961614
+    - opt8: 256.994037621393
+    - opt5: 497.41306986509306
 
   - Ours
-    - default: 605.5005417137588
-    - mt1: 196.3095515260894
-    - st: 185.59296570719334
-    - dmse: 242.3917642689959
-    - mae: 33.731860467220905
+    - default: 761.1614229705182
+    - mt1: 200.48068127744907
+    - st: 186.7675464081623
+    - dmse: 259.5070523797762
+    - mae: 39.58602408227127
 
 


### PR DESCRIPTION
For flacenc crate, "mimalloc" feature is still optional, but it's now default in "flacenc-bin" tool.