### PR TITLE
Code cleaning around stereo coding.

### DIFF
--- a/src/constant.rs
+++ b/src/constant.rs
@@ -102,17 +102,18 @@ pub mod rice {
 /// It's okay to use them in tests, but it's not okay to add another variable
 /// only for test functions.
 pub(crate) mod panic_msg {
-    pub const NO_ERROR_EXPECTED: &str =
-        "INTERNAL ERROR: Error emitted from the function designed not to return err.";
+    pub const DATA_INCONSISTENT: &str = "INTERNAL ERROR: Internal variable inconsistency detected.";
+    pub const ERROR_NOT_EXPECTED: &str =
+        "INTERNAL ERROR: Error occured in the function where it is not expected.";
+    pub const FRAMENUM_NOT_SET: &str =
+        "INTERNAL ERROR: Frame buffer is not properly initialized. (FrameNo. not set).";
     pub const MPMC_SEND_FAILED: &str =
         "INTERNAL ERROR: Critical error occured in multi-thread communication channel.";
     pub const MPMC_RECV_FAILED: &str =
         "INTERNAL ERROR: Critical error occured in multi-thread communication channel.";
     pub const MUTEX_LOCK_FAILED: &str = "INTERNAL ERROR: Couldn't get lock for mutex.";
     pub const MUTEX_DROP_FAILED: &str = "INTERNAL ERROR: Couldn't discard mutex.";
-    pub const FRAMENUM_NOT_SET: &str =
-        "INTERNAL ERROR: Frame buffer is not properly initialized. (FrameNo. not set).";
+    pub const NO_ERROR_EXPECTED: &str =
+        "INTERNAL ERROR: Error emitted from the function designed not to return err.";
     pub const THREAD_JOIN_FAILED: &str = "INTERNAL ERROR: Failed to wait thread termination.";
-    pub const ERROR_NOT_EXPECTED: &str =
-        "INTERNAL ERROR: Error occured in the function where it is not expected.";
 }


### PR DESCRIPTION
This commit also changes the internal storage for `SubFrame`s from `heapless::Vec` to `Vec` for memory efficiency.