### PR TITLE
"fakesimd" is now corresponding to not specifying "simd-nightly".

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,12 +47,12 @@ jobs:
       uses: ClementTsang/cargo-action@v0.0.3
       with:
         command: test
-        args: --verbose --features fakesimd
+        args: --verbose --no-default-features --features "par,mimalloc"
     - name: Run tests (CLI)
       uses: ClementTsang/cargo-action@v0.0.3
       with:
         command: test
-        args: --verbose --all-targets --features fakesimd
+        args: --verbose --all-targets --no-default-features
         directory: flacenc-bin
 
   lints:
@@ -86,9 +86,3 @@ jobs:
         command: clippy
         args: --tests -- -D warnings
         directory: flacenc-bin
-    - name: Clippy (with fakesimd feature)
-      uses: ClementTsang/cargo-action@v0.0.3
-      with:
-        command: clippy
-        args: --tests --features "fakesimd" -- -D warnings
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ repository = "https://github.com/yotarok/flacenc-rs/"
 debug = 1
 
 [features]
-default = ["par"]
+default = ["par", "simd-nightly"]
 experimental = ["dep:nalgebra"]
 par = ["dep:crossbeam-channel"]
-fakesimd = []
 mimalloc = ["dep:mimalloc"]
+simd-nightly = []
 
 [dependencies]
 crc = "2.1"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This crate provides some basic modules for building application customized FLAC
 (Free Lossless Audio Codec) encoder in rust programs.
 
-See [the auto-generated report](report/report.md) for the characteristics of the
+See [the auto-generated report](report/report.nightly.md) for the characteristics of the
 encoder compared to
 [FLAC reference implementation](https://xiph.org/flac/download.html).
 
@@ -16,18 +16,20 @@ encoder compared to
 Add the following line to your `Cargo.toml`:
 
 ```toml
-flacenc = { version = "0.2.0", feature = ["fakesimd"] }
+flacenc = { version = "0.2.0", default-features = false, features = ["par", "mimalloc"] }
 ```
 
 This crate is intended to be, and primarily developed with
 [`portable_simd`](https://github.com/rust-lang/project-portable-simd), and the
-`fakesimd` feature above is for emulating `portable_simd` in a stable toolchain.
-If you are using a nightly toolchain, use this crate without `fakesimd` as
-follows:
+`default-features = false` above is for backing-off to the fake SIMD
+implementation that can be compiled with a stable toolchain.  If you are using
+a nightly toolchain, use this crate with the default features as follows:
 
 ```toml
 flacenc = "0.2.0"
 ```
+
+This implicitly activates "simd-nightly" feature.
 
 ## Examples
 

--- a/codehealth.sh
+++ b/codehealth.sh
@@ -16,22 +16,22 @@
 set -e
 
 rustup default nightly
+cargo fmt --check
 cargo rustc --release -- -D warnings
 cargo build --release
-cargo test --features "experimental,par"
-cargo fmt --check
+cargo test --features "experimental,par,simd-nightly"
 cargo clippy --tests -- -D warnings
 cargo doc
 
 pushd flacenc-bin
-cargo test
 cargo fmt --check
+cargo test
 cargo clippy --tests -- -D warnings
 popd
 
 rustup default stable
-cargo rustc --release --features "fakesimd" -- -D warnings
-cargo build --release --features "fakesimd"
-cargo clippy --tests --features "fakesimd"
-cargo test --features "fakesimd,experimental,par"
+cargo rustc --release --no-default-features --features "par,experimental" -- -D warnings
+cargo build --release --no-default-features --features "par,experimental"
+cargo clippy --tests --no-default-features --features "par,experimental"
+cargo test --no-default-features --features "experimental,par"
 rustup default nightly

--- a/flacenc-bin/Cargo.lock
+++ b/flacenc-bin/Cargo.lock
@@ -238,25 +238,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,7 +296,6 @@ name = "flacenc"
 version = "0.2.0"
 dependencies = [
  "crc",
- "crossbeam-channel",
  "heapless",
  "md5",
  "mimalloc",

--- a/flacenc-bin/Cargo.toml
+++ b/flacenc-bin/Cargo.toml
@@ -21,15 +21,15 @@ codegen-units = 1
 name = "flacenc"
 path = "src/main.rs"
 
-
 [dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
-flacenc = { version = "0.2.0", path = "..", features = ["experimental", "mimalloc"] }
+flacenc = { version = "0.2.0", path = "..", default-features = false, features = ["experimental", "mimalloc"] }
 hound = "3.5.0"
 pprof = { version = "0.12", features = ["flamegraph", "protobuf-codec"], optional = true }
 toml = "0.5"
 
 
 [features]
+default = ["simd-nightly"]
 pprof = ["dep:pprof"]
-fakesimd = ["flacenc/fakesimd"]
+simd-nightly = ["flacenc/simd-nightly"]

--- a/report/report.nightly.md
+++ b/report/report.nightly.md
@@ -1,0 +1,36 @@
+
+# Encoder Comparison Report
+
+## Summary
+
+Sources used: wikimedia.i_love_you_california, wikimedia.winter_kiss, wikimedia.jazz_funk_no1_sax
+
+### Average compression rate
+
+  - Reference
+    - opt8lax: 0.5359108109154693
+    - opt8: 0.5359108109154693
+    - opt5: 0.5438954957635126
+
+  - Ours
+    - default: 0.5443052357800366
+    - mt1: 0.5443052357800366
+    - st: 0.5443052357800366
+    - dmse: 0.5418910269181569
+    - mae: 0.5374571118440491
+
+
+### Average compression speed (inverse RTF)
+  - Reference
+    - opt8lax: 261.0134038202119
+    - opt8: 257.8481383630919
+    - opt5: 500.4623861877681
+
+  - Ours
+    - default: 963.2261683200725
+    - mt1: 251.6231148668047
+    - st: 226.31808134958558
+    - dmse: 351.2952709685547
+    - mae: 43.48650746695992
+
+

--- a/report/report.stable.md
+++ b/report/report.stable.md
@@ -22,15 +22,15 @@ Sources used: wikimedia.i_love_you_california, wikimedia.winter_kiss, wikimedia.
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 261.167979695168
-    - opt8: 257.9872529862166
-    - opt5: 500.50488168568415
+    - opt8lax: 248.92398767923325
+    - opt8: 255.97794834207775
+    - opt5: 496.19469715719356
 
   - Ours
-    - default: 1003.3105480659425
-    - mt1: 254.39199016473688
-    - st: 226.6339640883368
-    - dmse: 356.7975006264205
-    - mae: 43.51012704892546
+    - default: 937.3578470516026
+    - mt1: 253.9439301684141
+    - st: 224.75310730444613
+    - dmse: 275.8804122357193
+    - mae: 33.71625646810446
 
 

--- a/run_reporter.sh
+++ b/run_reporter.sh
@@ -28,6 +28,13 @@ pytype testtool | true
 flake8 testtool
 
 pushd flacenc-bin
+cargo build --release --no-default-features
+popd
+python ./testtool/reporter.py
+mv report/report.md report/report.stable.md
+
+pushd flacenc-bin
 cargo build --release
 popd
 python ./testtool/reporter.py
+mv report/report.md report/report.nightly.md

--- a/src/arrayutils.rs
+++ b/src/arrayutils.rs
@@ -16,9 +16,9 @@
 
 use seq_macro::seq;
 
-#[cfg(feature = "fakesimd")]
+#[cfg(not(feature = "simd-nightly"))]
 use super::fakesimd as simd;
-#[cfg(not(feature = "fakesimd"))]
+#[cfg(feature = "simd-nightly")]
 use std::simd;
 
 // deinterleaver is often used in the I/O thread which can be a performance

--- a/src/coding.rs
+++ b/src/coding.rs
@@ -43,9 +43,9 @@ use super::source::Source;
 use crate::reusable;
 use crate::reuse;
 
-#[cfg(feature = "fakesimd")]
+#[cfg(not(feature = "simd-nightly"))]
 use super::fakesimd as simd;
-#[cfg(not(feature = "fakesimd"))]
+#[cfg(feature = "simd-nightly")]
 use std::simd;
 
 /// Computes rice encoding of a scalar (used in `encode_residual`.)
@@ -58,7 +58,7 @@ const fn quotients_and_remainders(err: i32, rice_p: u8) -> (u32, u32) {
 
 /// Computes rice encoding of a SIMD vector (used in `encode_residual`.)
 #[inline]
-#[cfg(not(feature = "fakesimd"))]
+#[cfg(feature = "simd-nightly")]
 fn quotients_and_remainders_simd<const N: usize>(
     err_v: simd::Simd<i32, N>,
     rice_p: u8,
@@ -84,7 +84,7 @@ fn quotients_and_remainders_simd<const N: usize>(
 ///
 /// TODO: Probably, it's better to introduce another abstraction for `as_simd`
 /// e.g. SIMD-version of `map` so we can do conditional compilation there.
-#[cfg(not(feature = "fakesimd"))]
+#[cfg(feature = "simd-nightly")]
 #[inline]
 fn encode_residual_partition(
     start: usize,
@@ -118,7 +118,7 @@ fn encode_residual_partition(
 }
 
 /// Computes encoding of each residual partition. (without SIMD)
-#[cfg(feature = "fakesimd")]
+#[cfg(not(feature = "simd-nightly"))]
 #[inline]
 fn encode_residual_partition(
     start: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #![doc = include_str!("../README.md")]
-#![cfg_attr(not(feature = "fakesimd"), feature(portable_simd))]
+#![cfg_attr(feature = "simd-nightly", feature(portable_simd))]
 // Note that clippy attributes should be in sync with those declared in "main.rs"
 #![warn(clippy::all, clippy::nursery, clippy::pedantic, clippy::cargo)]
 // Some of clippy::pedantic rules are actually useful, so use it with a lot of
@@ -60,7 +60,7 @@ pub mod component;
 pub mod config;
 pub mod constant;
 pub mod error;
-#[cfg(feature = "fakesimd")]
+#[cfg(not(feature = "simd-nightly"))]
 pub(crate) mod fakesimd;
 pub(crate) mod lpc;
 #[cfg(feature = "par")]

--- a/src/lpc.rs
+++ b/src/lpc.rs
@@ -27,9 +27,9 @@ use super::constant::qlpc::MIN_SHIFT as QLPC_MIN_SHIFT;
 use crate::reusable;
 use crate::reuse;
 
-#[cfg(feature = "fakesimd")]
+#[cfg(not(feature = "simd-nightly"))]
 use super::fakesimd as simd;
-#[cfg(not(feature = "fakesimd"))]
+#[cfg(feature = "simd-nightly")]
 use std::simd;
 
 use simd::SimdInt;
@@ -344,7 +344,7 @@ pub fn weighted_auto_correlation<F>(order: usize, signal: &[f32], dest: &mut [f3
 where
     F: Fn(usize) -> f32,
 {
-    #[cfg(not(feature = "fakesimd"))]
+    #[cfg(feature = "simd-nightly")]
     {
         // The current implementation is inefficient with fakesimd when order
         // is low. So, here we still have a scalar version of it.
@@ -364,7 +364,7 @@ where
             weighted_auto_correlation_simd::<_, 64>(order, signal, dest, weight_fn);
         }
     }
-    #[cfg(feature = "fakesimd")]
+    #[cfg(not(feature = "simd-nightly"))]
     {
         assert!(dest.len() >= order);
         for p in &mut *dest {

--- a/src/rice.rs
+++ b/src/rice.rs
@@ -23,9 +23,9 @@ use super::constant::rice::MIN_PARTITION_SIZE as MIN_RICE_PARTITION_SIZE;
 use crate::reusable;
 use crate::reuse;
 
-#[cfg(feature = "fakesimd")]
+#[cfg(not(feature = "simd-nightly"))]
 use super::fakesimd as simd;
-#[cfg(not(feature = "fakesimd"))]
+#[cfg(feature = "simd-nightly")]
 use std::simd;
 
 use simd::SimdInt;

--- a/testtool/reporter.py
+++ b/testtool/reporter.py
@@ -225,10 +225,6 @@ def main():
     testenc_out_root = report_root / "testenc_out"
     report_md_out = report_root / "report.md"
 
-    # build
-    logged(subprocess.check_call)(
-        ["bash", "-c", f"cd {project_root}/flacenc-bin; cargo build --release"]
-    )
     print("Running reference encoder.")
     ref_run_results = run_encoder(
         inputs, refenc_out_root, REFERENCE_BINPATH, REFERENCE_ENCODER_OPTS


### PR DESCRIPTION
This is for keeping additive structure of features. We still keep "simd-nightly" as a default, but this might be removed when it's better to do so.