### PR TITLE
Change to use u64 MemSink for faster `Residual` serialization.

### DIFF
--- a/report/report.nightly.md
+++ b/report/report.nightly.md
@@ -22,15 +22,15 @@ Sources used: wikimedia.i_love_you_california, wikimedia.winter_kiss, wikimedia.
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 259.8257124378235
-    - opt8: 263.2766248081781
-    - opt5: 493.4280664340811
+    - opt8lax: 256.85639070106544
+    - opt8: 252.72458283071833
+    - opt5: 475.57254096934474
 
   - Ours
-    - default: 1107.957821565425
-    - mt1: 264.44060845160243
-    - st: 229.47859532955343
-    - dmse: 353.25807291624193
-    - mae: 34.56012233282272
+    - default: 1012.9075504565544
+    - mt1: 262.0679354368241
+    - st: 246.49203688375619
+    - dmse: 300.45065550986544
+    - mae: 34.802276716024025
 
 

--- a/report/report.stable.md
+++ b/report/report.stable.md
@@ -22,15 +22,15 @@ Sources used: wikimedia.i_love_you_california, wikimedia.winter_kiss, wikimedia.
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 258.0402168520241
-    - opt8: 261.0415646723217
-    - opt5: 491.56993699591504
+    - opt8lax: 226.24005186004783
+    - opt8: 226.40229065065654
+    - opt5: 437.13762185059875
 
   - Ours
-    - default: 1059.325736841261
-    - mt1: 261.4959145648291
-    - st: 230.95728111644664
-    - dmse: 344.9639521733453
-    - mae: 43.5342649562942
+    - default: 916.9501774939099
+    - mt1: 265.13363763089194
+    - st: 255.5052743718486
+    - dmse: 327.60848736772977
+    - mae: 40.73513170359286
 
 


### PR DESCRIPTION
This change also unrolls a loop in `Residual` serialization.