### PR TITLE
Change `Frame::count_bits` to use precomputed value.

### DIFF
--- a/report/report.nightly.md
+++ b/report/report.nightly.md
@@ -22,15 +22,15 @@ Sources used: wikimedia.i_love_you_california, wikimedia.winter_kiss, wikimedia.
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 256.85639070106544
-    - opt8: 252.72458283071833
-    - opt5: 475.57254096934474
+    - opt8lax: 255.54088748943823
+    - opt8: 254.61963425057687
+    - opt5: 496.09199239661194
 
   - Ours
-    - default: 1012.9075504565544
-    - mt1: 262.0679354368241
-    - st: 246.49203688375619
-    - dmse: 300.45065550986544
-    - mae: 34.802276716024025
+    - default: 1143.0490504956447
+    - mt1: 271.0308435401395
+    - st: 251.59408731819175
+    - dmse: 373.0922245610626
+    - mae: 36.18902987456826
 
 

--- a/report/report.stable.md
+++ b/report/report.stable.md
@@ -22,15 +22,15 @@ Sources used: wikimedia.i_love_you_california, wikimedia.winter_kiss, wikimedia.
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 226.24005186004783
-    - opt8: 226.40229065065654
-    - opt5: 437.13762185059875
+    - opt8lax: 252.20384837760537
+    - opt8: 261.75123878588147
+    - opt5: 474.98327988294767
 
   - Ours
-    - default: 916.9501774939099
-    - mt1: 265.13363763089194
-    - st: 255.5052743718486
-    - dmse: 327.60848736772977
-    - mae: 40.73513170359286
+    - default: 1094.335046364402
+    - mt1: 279.19700261630067
+    - st: 246.057710662378
+    - dmse: 375.1870166006766
+    - mae: 44.01332061523976
 
 


### PR DESCRIPTION
`count_bits` was not using precomputed value as it is considered to be very light-weight. However, now in fact, it is visible and more importantly it is called twice in a non-parallelized part of the code. Therefore, this commit will improve parallelism.