### PR TITLE
Generalize `MemSink<u8>::into_byte_slice` to `MemSink::into_slice`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ let mut sink = flacenc::bitsink::ByteSink::new();
 flac_stream.write(&mut sink);
 
 // Then, e.g. you can write it to a file.
-std::fs::write("/dev/null", sink.as_byte_slice());
+std::fs::write("/dev/null", sink.as_slice());
 
 // or you can write only a specific frame.
 let mut sink = flacenc::bitsink::ByteSink::new();

--- a/flacenc-bin/src/main.rs
+++ b/flacenc-bin/src/main.rs
@@ -102,7 +102,7 @@ fn write_stream<F: Write>(stream: &Stream, file: &mut F) -> usize {
     let bits = stream.count_bits();
     let mut bv = flacenc::bitsink::ByteSink::with_capacity(bits);
     stream.write(&mut bv).expect("Bitstream formatting failed.");
-    file.write_all(bv.as_byte_slice())
+    file.write_all(bv.as_slice())
         .expect("Failed to write a bitstream to the file.");
     bits
 }

--- a/src/component.rs
+++ b/src/component.rs
@@ -878,7 +878,7 @@ impl Frame {
     /// let mut sink_ref = ByteSink::new();
     /// frame_cloned.write(&mut sink_ref);
     ///
-    /// assert_eq!(sink.as_byte_slice(), sink_ref.as_byte_slice());
+    /// assert_eq!(sink.as_slice(), sink_ref.as_slice());
     /// ```
     pub fn precompute_bitstream(&mut self) {
         if self.precomputed_bitstream.is_some() {
@@ -886,7 +886,7 @@ impl Frame {
         }
         let mut dest = ByteSink::with_capacity(self.count_bits());
         if self.write(&mut dest).is_ok() {
-            self.precomputed_bitstream = Some(dest.into_bytes());
+            self.precomputed_bitstream = Some(dest.into_inner());
         }
     }
 
@@ -1107,8 +1107,8 @@ impl FrameHeader {
     ///
     /// // 16-th bit denotes blocking strategy and it should be 0 (fixed blocking mode)
     /// // after setting the frame number.
-    /// assert_eq!(sink.as_byte_slice()[1] & 0x01u8, 0u8);
-    /// assert_eq!(sink.as_byte_slice()[4], 12u8);
+    /// assert_eq!(sink.as_slice()[1] & 0x01u8, 0u8);
+    /// assert_eq!(sink.as_slice()[4], 12u8);
     /// ```
     pub fn set_frame_number(&mut self, frame_number: u32) {
         self.variable_block_size = false;
@@ -1223,9 +1223,9 @@ impl BitRepr for FrameHeader {
             }
             header_buffer.write_lsbs(foot, footsize).unwrap();
 
-            dest.write_bytes_aligned(header_buffer.as_byte_slice())
+            dest.write_bytes_aligned(header_buffer.as_slice())
                 .map_err(OutputError::<S>::from_sink)?;
-            dest.write(HEADER_CRC.checksum(header_buffer.as_byte_slice()))
+            dest.write(HEADER_CRC.checksum(header_buffer.as_slice()))
                 .map_err(OutputError::<S>::from_sink)?;
             Ok(())
         })

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -158,8 +158,7 @@ where
 
     let mut bv: ByteSink = ByteSink::with_capacity(stream.count_bits());
     stream.write(&mut bv).expect("Bitstream formatting failed.");
-    file.write_all(bv.as_byte_slice())
-        .expect("File write failed.");
+    file.write_all(bv.as_slice()).expect("File write failed.");
 
     let flac_path = file.into_temp_path();
 


### PR DESCRIPTION
This is a breaking API change.