### PR TITLE
Remove unused "toml" dependency in the library.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ num-traits = "0.2"
 rustversion = "1.0"
 seq-macro = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-toml = "0.5"
 
 [dev-dependencies]
 bitvec = "1.0.0"
@@ -42,3 +41,4 @@ once_cell = "1.10.0"
 rand = "0.8.5"
 rstest = "0.18.2"
 tempfile = "3"
+toml = "0.5"

--- a/flacenc-bin/Cargo.lock
+++ b/flacenc-bin/Cargo.lock
@@ -324,7 +324,6 @@ dependencies = [
  "rustversion",
  "seq-macro",
  "serde",
- "toml",
 ]
 
 [[package]]


### PR DESCRIPTION
"toml" is still used in tests and "flacenc-bin" but there's no dependency from the library core codes.