### PR TITLE
Add benchmarks with non-zero signals.

### DIFF
--- a/report/bench_results.txt
+++ b/report/bench_results.txt
@@ -1,20 +1,22 @@
 
-running 15 tests
-test arrayutils::bench::deinterleave_ch2_direct_call ... bench:       4,905 ns/iter (+/- 82)
-test arrayutils::bench::simd_packing                 ... bench:         174 ns/iter (+/- 2)
-test coding::bench::fixed_lpc_encoding_zero          ... bench:      12,016 ns/iter (+/- 661)
-test coding::bench::fixed_size_frame_encoder_zero    ... bench:      14,924 ns/iter (+/- 178)
-test coding::bench::normal_qlpc_noise                ... bench:      15,301 ns/iter (+/- 610)
-test coding::bench::residual_encoder_zero            ... bench:       3,499 ns/iter (+/- 141)
-test coding::bench::residual_partition_encoder_zero  ... bench:       1,488 ns/iter (+/- 128)
-test component::bench::residual_write_to_u64s        ... bench:       8,936 ns/iter (+/- 298)
-test lpc::bench::auto_corr_order14_zero              ... bench:       7,545 ns/iter (+/- 35)
-test lpc::bench::quantized_parameter_error_dc        ... bench:       2,461 ns/iter (+/- 136)
-test lpc::bench::tukey_window_zero                   ... bench:         677 ns/iter (+/- 10)
-test rice::bench::bit_table_creation                 ... bench:       1,173 ns/iter (+/- 36)
-test rice::bench::find_prc_parameter                 ... bench:       2,126 ns/iter (+/- 56)
-test rice::bench::rice_find_minimizer                ... bench:           2 ns/iter (+/- 0)
-test source::bench::feeding_bytes_to_context         ... bench:      21,056 ns/iter (+/- 1,531)
+running 17 tests
+test arrayutils::bench::deinterleave_ch2_direct_call    ... bench:       4,893 ns/iter (+/- 100)
+test arrayutils::bench::simd_packing                    ... bench:         233 ns/iter (+/- 4)
+test coding::bench::fixed_lpc_encoding_zero             ... bench:      12,138 ns/iter (+/- 289)
+test coding::bench::fixed_size_frame_encoder_noisy_sine ... bench:     161,143 ns/iter (+/- 11,546)
+test coding::bench::fixed_size_frame_encoder_pure_sine  ... bench:     162,299 ns/iter (+/- 8,260)
+test coding::bench::fixed_size_frame_encoder_zero       ... bench:      14,881 ns/iter (+/- 189)
+test coding::bench::normal_qlpc_noise                   ... bench:      15,569 ns/iter (+/- 201)
+test coding::bench::residual_encoder_zero               ... bench:       3,526 ns/iter (+/- 33)
+test coding::bench::residual_partition_encoder_zero     ... bench:       1,388 ns/iter (+/- 14)
+test component::bench::residual_write_to_u64s           ... bench:       9,005 ns/iter (+/- 177)
+test lpc::bench::auto_corr_order14_zero                 ... bench:       7,549 ns/iter (+/- 136)
+test lpc::bench::quantized_parameter_error_dc           ... bench:       2,320 ns/iter (+/- 89)
+test lpc::bench::tukey_window_zero                      ... bench:         697 ns/iter (+/- 8)
+test rice::bench::bit_table_creation                    ... bench:       1,159 ns/iter (+/- 7)
+test rice::bench::find_prc_parameter                    ... bench:       2,126 ns/iter (+/- 43)
+test rice::bench::rice_find_minimizer                   ... bench:           2 ns/iter (+/- 0)
+test source::bench::feeding_bytes_to_context            ... bench:      21,049 ns/iter (+/- 274)
 
-test result: ok. 0 passed; 0 failed; 0 ignored; 15 measured; 85 filtered out; finished in 12.02s
+test result: ok. 0 passed; 0 failed; 0 ignored; 17 measured; 85 filtered out; finished in 10.48s
 

--- a/src/coding.rs
+++ b/src/coding.rs
@@ -678,6 +678,42 @@ mod bench {
     }
 
     #[bench]
+    fn fixed_size_frame_encoder_pure_sine(b: &mut Bencher) {
+        let cfg = &config::Encoder::default();
+        let stream_info = StreamInfo::new(48000, 2, 16);
+        let mut fb = FrameBuf::with_size(2, 4096);
+        // input is always zero, so it should use Constant and fast.
+        let signal = &test_helper::sinusoid_plus_noise(4096 * 2, 200, 10000.0, 0i32);
+        fb.fill_interleaved(&signal).unwrap();
+        b.iter(|| {
+            encode_fixed_size_frame(
+                black_box(cfg),
+                black_box(&fb),
+                black_box(123usize),
+                &stream_info,
+            )
+        });
+    }
+
+    #[bench]
+    fn fixed_size_frame_encoder_noisy_sine(b: &mut Bencher) {
+        let cfg = &config::Encoder::default();
+        let stream_info = StreamInfo::new(48000, 2, 16);
+        let mut fb = FrameBuf::with_size(2, 4096);
+        // input is always zero, so it should use Constant and fast.
+        let signal = &test_helper::sinusoid_plus_noise(4096 * 2, 200, 10000.0, 10000i32);
+        fb.fill_interleaved(&signal).unwrap();
+        b.iter(|| {
+            encode_fixed_size_frame(
+                black_box(cfg),
+                black_box(&fb),
+                black_box(123usize),
+                &stream_info,
+            )
+        });
+    }
+
+    #[bench]
     fn normal_qlpc_noise(b: &mut Bencher) {
         let cfg = &config::SubFrameCoding::default();
         let signal =


### PR DESCRIPTION
Encoding of zero-signal is not realistic because it always shortcuts the rest of encoding routines by returning `Constant`. Added two benchmarks can be assumed to give a bit more realistic measures.