### PR TITLE
Change components to be verifiable as a preparation for fuzz testing.

### DIFF
--- a/src/coding.rs
+++ b/src/coding.rs
@@ -291,7 +291,7 @@ fn encode_subframe(
 ) -> SubFrame {
     if config.use_constant && is_constant(samples) {
         // Assuming constant is always best if it's applicable.
-        Constant::new(samples[0], bits_per_sample).into()
+        Constant::new(samples.len(), samples[0], bits_per_sample).into()
     } else {
         let baseline_bits =
             Verbatim::count_bits_from_metadata(samples.len(), bits_per_sample as usize);
@@ -338,7 +338,7 @@ fn encode_frame_impl(
     }
 
     // for Claxon compatibility.
-    frame.header_mut().reset_sample_size(stream_info);
+    frame.header_mut().reset_sample_size_spec(stream_info);
 
     frame
 }

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -36,6 +36,9 @@ pub const MAX_BLOCKSIZE: usize = 32767;
 /// Maximum number of channels.
 pub const MAX_CHANNELS: usize = 8;
 
+/// Minimum bits-per-sample supported. (4 in the specification.)
+pub const MIN_BITS_PER_SAMPLE: usize = 8;
+
 /// Maximum bits-per-sample supported. (32 in the specification.)
 pub const MAX_BITS_PER_SAMPLE: usize = 24;
 

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -27,6 +27,7 @@ use super::arrayutils::le_bytes_to_i32s;
 use super::bitsink::ByteSink;
 use super::component::BitRepr;
 use super::component::Stream;
+use super::error::Verify;
 use super::source::MemSource;
 use super::source::Seekable;
 use super::source::Source;
@@ -153,6 +154,8 @@ where
     Enc: Fn(MemSource) -> Stream,
 {
     let stream = encoder(src.clone());
+
+    assert!(stream.verify().is_ok());
 
     let mut file = NamedTempFile::new().expect("Failed to create temp file.");
 


### PR DESCRIPTION
This commit also renames `FrameHeader::sample_size` to `sample_size_spec` (non-breaking change) because it is confusing whether this field contains the number of bits, or an internal representation for the number of bits.