### PR TITLE
Refactor test_helper and make test signal generator exportable.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ debug = 1
 [features]
 default = ["log", "par", "serde"]
 
+__export_sigen = ["dep:rand"]
 experimental = ["dep:nalgebra"]
 log = ["dep:log"]
 mimalloc = ["dep:mimalloc"]
@@ -34,6 +35,7 @@ log = { version = "0.4", optional = true }
 mimalloc = { version = "0.1.39", default-features = false, optional = true }
 nalgebra = { version = "0.32", optional = true }
 num-traits = "0.2"
+rand = { version = "0.8.5", optional = true }
 rustversion = "1.0"
 seq-macro = "0.3"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/src/component.rs
+++ b/src/component.rs
@@ -2117,7 +2117,8 @@ mod seal_bit_repr {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helper;
+    use crate::sigen;
+    use crate::sigen::Signal;
 
     use bitvec::bits;
     use bitvec::prelude::BitVec;
@@ -2284,10 +2285,14 @@ mod tests {
     #[test]
     fn stream_info_update() {
         let mut stream_info = StreamInfo::new(44100, 2, 16);
-        let framebuf = test_helper::constant_plus_noise(256 * 2, 123, 21);
+        let framebuf = sigen::Dc::new(0.01)
+            .noise(0.002)
+            .to_vec_quantized(16, 256 * 2);
         let frame1 = make_frame(&stream_info, &framebuf, 0);
         stream_info.update_frame_info(&frame1);
-        let framebuf = test_helper::constant_plus_noise(192 * 2, 234, 32);
+        let framebuf = sigen::Dc::new(0.02)
+            .noise(0.1)
+            .to_vec_quantized(16, 192 * 2);
         let frame2 = make_frame(&stream_info, &framebuf, 256);
         stream_info.update_frame_info(&frame2);
 
@@ -2347,7 +2352,9 @@ mod tests {
     #[test]
     fn frame_bitstream_precomputataion() -> Result<(), OutputError<BitVec<usize>>> {
         let stream_info = StreamInfo::new(44100, 2, 16);
-        let samples = test_helper::sinusoid_plus_noise(256 * 2, 128, 200.0, 100);
+        let samples = sigen::Sine::new(128, 0.2)
+            .noise(0.1)
+            .to_vec_quantized(12, 512);
         let mut frame = make_frame(&stream_info, &samples, 0);
         let mut bv_ref: BitVec<usize> = BitVec::new();
         let frame_cloned = frame.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,8 @@ pub(crate) mod lpc;
 pub(crate) mod par;
 pub(crate) mod repeat;
 pub(crate) mod rice;
+#[cfg(any(test, feature = "__export_sigen"))]
+pub mod sigen;
 pub mod source;
 
 #[cfg(test)]
@@ -160,6 +162,10 @@ mod tests {
     // end-to-end, but transparent test.
     #[cfg(feature = "serde")]
     use super::*;
+    #[cfg(feature = "serde")]
+    use crate::sigen;
+    #[cfg(feature = "serde")]
+    use crate::sigen::Signal;
     #[cfg(feature = "serde")]
     use rstest::rstest;
 
@@ -200,9 +206,11 @@ multithread = false
 
         let mut channel_signals = vec![];
         for _ch in 0..channels {
-            channel_signals.push(test_helper::sinusoid_plus_noise(
-                signal_len, 36, 10000.0, 123,
-            ));
+            channel_signals.push(
+                sigen::Sine::new(36, 0.4)
+                    .noise(0.04)
+                    .to_vec_quantized(bits_per_sample, signal_len),
+            );
         }
 
         let mut signal = vec![];

--- a/src/lpc.rs
+++ b/src/lpc.rs
@@ -713,6 +713,8 @@ mod tests {
     use super::*;
     use crate::assert_close;
     use crate::assert_finite;
+    use crate::sigen;
+    use crate::sigen::Signal;
     use crate::test_helper;
 
     use rstest::rstest;
@@ -800,7 +802,9 @@ mod tests {
     #[rstest]
     fn qlpc_recovery(#[values(2, 12, 24)] lpc_order: usize) {
         let coef_prec: usize = 12;
-        let signal = test_helper::sinusoid_plus_noise(1024, 32, 30000.0, 128);
+        let signal = sigen::Sine::new(32, 0.8)
+            .noise(0.01)
+            .to_vec_quantized(16, 1024);
 
         let lpc_coefs = LPC_ESTIMATOR.with(|estimator| {
             estimator.borrow_mut().lpc_from_auto_corr(

--- a/src/sigen.rs
+++ b/src/sigen.rs
@@ -1,0 +1,294 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test signal generator module.
+//!
+//! This module is primarily intended to be used for tests. However, unlike
+//! a module in `test_helper.rs`, this module is intended to be exposed to the
+//! outside of the crate for external testing frameworks
+//! (specifically for cargo-fuzz).
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+use rand::Rng;
+use rand::SeedableRng;
+
+/// Test signal generators.
+pub trait Signal: std::fmt::Debug {
+    /// Generates a signal from t=`sample_offset` and fills the buffer `dest`.
+    fn fill_buffer(&self, sample_offset: usize, dest: &mut [f32]);
+
+    /// Generates a signal and returns `Vec` containing quantized ints.
+    fn to_vec_quantized(&self, bits_per_sample: usize, block_size: usize) -> Vec<i32> {
+        assert!(bits_per_sample <= 24);
+        assert!(bits_per_sample > 4);
+        // note that scalefactor below can make samples exceed iXX::MAX by 1.
+        let scalefactor = 1usize << (bits_per_sample - 1);
+        let min_target = -((1usize << (bits_per_sample - 1)) as i32);
+        let max_target = (1usize << (bits_per_sample - 1)) as i32 - 1i32;
+
+        let mut ret = vec![0i32; block_size];
+        let mut buffer = vec![0.0f32; block_size];
+        self.fill_buffer(0, &mut buffer);
+
+        for (p, x) in ret.iter_mut().zip(buffer.iter()) {
+            *p = (scalefactor as f32 * x)
+                .round()
+                .clamp(min_target as f32, max_target as f32) as i32;
+        }
+        ret
+    }
+
+    /// Decorate the signal generator with output clipping.
+    fn clip(self) -> Clip<Self>
+    where
+        Self: Sized,
+    {
+        Clip::new(self)
+    }
+
+    /// Mixes noise
+    fn noise(self, amplitude: f32) -> Mix<Self, Noise>
+    where
+        Self: Sized,
+    {
+        self.mix(Noise::new(amplitude))
+    }
+
+    /// Mixes signal from the other generator
+    fn mix<T: Signal + Sized>(self, other: T) -> Mix<Self, T>
+    where
+        Self: Sized,
+    {
+        Mix::new(1.0, self, 1.0, other)
+    }
+
+    /// Concats `other` signal after `offset_time` samples are generated.
+    fn concat<T: Signal + Sized>(self, offset_time: usize, other: T) -> Switch<Self, T>
+    where
+        Self: Sized,
+    {
+        Switch::new(self, offset_time, other)
+    }
+}
+
+macro_rules! impl_signal_for_pointers {
+    ($pointertype:ident) => {
+        impl<T: Signal + ?Sized> Signal for $pointertype<T> {
+            fn fill_buffer(&self, sample_offset: usize, dest: &mut [f32]) {
+                <$pointertype<T> as AsRef<T>>::as_ref(self).fill_buffer(sample_offset, dest);
+            }
+        }
+    };
+}
+
+impl_signal_for_pointers!(Box);
+impl_signal_for_pointers!(Rc);
+impl_signal_for_pointers!(Arc);
+
+/// Generator for constant signals.
+#[derive(Clone, Debug)]
+pub struct Dc {
+    offset: f32,
+}
+
+impl Dc {
+    /// Constructs new `Dc` signal.
+    pub fn new(offset: f32) -> Self {
+        Self { offset }
+    }
+}
+
+impl Signal for Dc {
+    fn fill_buffer(&self, _offset: usize, dest: &mut [f32]) {
+        for p in dest {
+            *p = self.offset;
+        }
+    }
+}
+
+/// Generator for a sinusoidal wave.
+#[derive(Clone, Debug)]
+pub struct Sine {
+    period: usize,
+    amplitude: f32,
+    initial_phase: f32,
+}
+
+impl Sine {
+    /// Constructs new sine wave signal with `period` and `amplitude`.
+    pub fn new(period: usize, amplitude: f32) -> Self {
+        let initial_phase = 0.0;
+        Self {
+            period,
+            amplitude,
+            initial_phase,
+        }
+    }
+
+    pub fn with_initial_phase(period: usize, amplitude: f32, initial_phase: f32) -> Self {
+        Self {
+            period,
+            amplitude,
+            initial_phase,
+        }
+    }
+}
+
+impl Signal for Sine {
+    fn fill_buffer(&self, offset: usize, dest: &mut [f32]) {
+        let period = self.period as f32;
+        for (t, p) in dest.iter_mut().enumerate() {
+            let t = (t + offset) as f32;
+            *p = self.amplitude
+                * f32::sin(self.initial_phase + 2.0 * std::f32::consts::PI * t / period);
+        }
+    }
+}
+
+/// Generator for a uniform random white noise.
+#[derive(Clone, Debug)]
+pub struct Noise {
+    seed0: u64,
+    amplitude: f32,
+}
+
+impl Noise {
+    /// Constructs new noise generator.
+    pub fn new(amplitude: f32) -> Self {
+        let seed0: u64 = rand::thread_rng().gen();
+        Self { seed0, amplitude }
+    }
+
+    /// Constructs new noise generator with specifying a seed.
+    pub fn with_seed(seed0: u64, amplitude: f32) -> Self {
+        Self { seed0, amplitude }
+    }
+}
+
+impl Signal for Noise {
+    /// Fills buffer with the uniform random values.
+    ///
+    /// # Note
+    ///
+    /// This method doesn't ensure reproducibility if it is called in an
+    /// arbitraly order, e.g.
+    /// `noise.fill_buffer(0, &mut dest[..])` generate different results from
+    /// `noise.fill_buffer(0, &mut dest[0..10])` and
+    /// `noise.fill_buffer(10, &mut dest[10..])`.
+    fn fill_buffer(&self, offset: usize, dest: &mut [f32]) {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(self.seed0.wrapping_add(offset as u64));
+        for p in dest {
+            *p = self.amplitude * 2.0 * (rng.sample::<f32, _>(rand::distributions::Open01) - 0.5);
+        }
+    }
+}
+
+/// Decorator that mixes outputs from the inner generators.
+#[derive(Clone, Debug)]
+pub struct Mix<T1: Signal + Sized, T2: Signal + Sized> {
+    weight1: f32,
+    weight2: f32,
+    signal1: T1,
+    signal2: T2,
+}
+
+impl<T1: Signal + Sized, T2: Signal + Sized> Mix<T1, T2> {
+    /// Constructs new two-inputs mixer.
+    pub fn new(weight1: f32, signal1: T1, weight2: f32, signal2: T2) -> Self {
+        Self {
+            weight1,
+            weight2,
+            signal1,
+            signal2,
+        }
+    }
+}
+
+impl<T1: Signal + Sized, T2: Signal + Sized> Signal for Mix<T1, T2> {
+    fn fill_buffer(&self, offset: usize, dest: &mut [f32]) {
+        for p in &mut *dest {
+            *p = 0.0f32;
+        }
+
+        let mut buf = vec![0.0f32; dest.len()];
+        self.signal1.fill_buffer(offset, &mut buf);
+        for (p, x) in dest.iter_mut().zip(buf.iter()) {
+            *p += self.weight1 * *x;
+        }
+        self.signal2.fill_buffer(offset, &mut buf);
+        for (p, x) in dest.iter_mut().zip(buf.iter()) {
+            *p += self.weight2 * *x;
+        }
+    }
+}
+
+/// Decorator that clips the output of the inner generator.
+#[derive(Clone, Debug)]
+pub struct Clip<T: Signal + Sized> {
+    inner: T,
+    min: f32,
+    max: f32,
+}
+
+impl<T: Signal + Sized> Clip<T> {
+    /// Constructs a clipper.
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            min: -1.0,
+            max: 1.0,
+        }
+    }
+}
+
+impl<T: Signal + Sized> Signal for Clip<T> {
+    fn fill_buffer(&self, offset: usize, dest: &mut [f32]) {
+        self.inner.fill_buffer(offset, dest);
+        for p in dest {
+            *p = p.clamp(self.min, self.max);
+        }
+    }
+}
+
+/// Decorator that switches multiple generatros depending on the timestamp.
+#[derive(Clone, Debug)]
+pub struct Switch<T1: Signal + Sized, T2: Signal + Sized> {
+    input1: T1,
+    offset: usize,
+    input2: T2,
+}
+
+impl<T1: Signal + Sized, T2: Signal + Sized> Switch<T1, T2> {
+    /// Cosntructs a switcher.
+    pub fn new(input1: T1, offset: usize, input2: T2) -> Self {
+        Self {
+            input1,
+            offset,
+            input2,
+        }
+    }
+}
+
+impl<T1: Signal + Sized, T2: Signal + Sized> Signal for Switch<T1, T2> {
+    fn fill_buffer(&self, offset: usize, dest: &mut [f32]) {
+        // not very efficient, but let's keep it simple.
+        // use `input1` to fill the entire buffer
+        self.input1.fill_buffer(offset, dest);
+        // and then overwrite the later part of the signal.
+        self.input2
+            .fill_buffer(offset + self.offset, &mut dest[self.offset..]);
+    }
+}

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -15,12 +15,9 @@
 #![allow(clippy::missing_panics_doc)]
 
 use std::collections::BTreeMap;
-use std::f32::consts::PI;
 use std::io::Write;
 
 use once_cell::sync::Lazy;
-use rand::distributions::Distribution;
-use rand::distributions::Uniform;
 use tempfile::NamedTempFile;
 
 use super::arrayutils::le_bytes_to_i32s;
@@ -58,37 +55,6 @@ macro_rules! assert_finite {
             );
         }
     }};
-}
-
-/// Generates a test signal with sinusoid and uniform-white noise.
-#[allow(dead_code)]
-pub fn sinusoid_plus_noise(
-    block_size: usize,
-    period: usize,
-    amplitude: f32,
-    noise_width: i32,
-) -> Vec<i32> {
-    let mut rng = rand::thread_rng();
-    let period = period as f32;
-    let die = Uniform::from(-noise_width..=noise_width);
-    let mut ret = Vec::new();
-    for t in 0..block_size {
-        let sin = (amplitude * (2.0 * (t as f32) * PI / period).sin()) as i32;
-        ret.push(sin + die.sample(&mut rng));
-    }
-    ret
-}
-
-/// Generates DC signal with constant offset and random uniform-white noise.
-#[allow(dead_code)]
-pub fn constant_plus_noise(block_size: usize, dc_offset: i32, noise_width: i32) -> Vec<i32> {
-    let mut rng = rand::thread_rng();
-    let die = Uniform::from(-noise_width..=noise_width);
-    let mut ret = Vec::new();
-    for _t in 0..block_size {
-        ret.push(dc_offset + die.sample(&mut rng));
-    }
-    ret
 }
 
 #[allow(clippy::similar_names)]


### PR DESCRIPTION
This is done as a preparation for fuzz testing that must be implemented as an external crate.