### PR TITLE
Rename `{MIN|MAX}_BLOCKSIZE` to `{MIN|MAX}_BLOCK_SIZE`.

### DIFF
--- a/fuzz/fuzz_targets/frame_encode.rs
+++ b/fuzz/fuzz_targets/frame_encode.rs
@@ -150,7 +150,7 @@ impl Input {
 impl<'a> Arbitrary<'a> for Input {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self, arbitrary::Error> {
         let channel_count = u.int_in_range(1usize..=constant::MAX_CHANNELS)?;
-        let block_size = u.int_in_range(constant::MIN_BLOCKSIZE..=constant::MAX_BLOCKSIZE)?;
+        let block_size = u.int_in_range(constant::MIN_BLOCK_SIZE..=constant::MAX_BLOCK_SIZE)?;
         let sample_rate = u.int_in_range(1usize..=192_000)?;
         let bits_per_sample = (u.int_in_range(2u8..=6u8)? * 4) as usize;
 

--- a/src/coding.rs
+++ b/src/coding.rs
@@ -34,8 +34,8 @@ use super::config;
 use super::constant::fixed::MAX_LPC_ORDER as MAX_FIXED_LPC_ORDER;
 use super::constant::panic_msg;
 use super::constant::qlpc::MAX_ORDER as MAX_LPC_ORDER;
-use super::constant::MAX_BLOCKSIZE;
-use super::constant::MIN_BLOCKSIZE;
+use super::constant::MAX_BLOCK_SIZE;
+use super::constant::MIN_BLOCK_SIZE;
 use super::error::EncodeError;
 use super::error::VerifyError;
 use super::lpc;
@@ -570,17 +570,17 @@ pub fn encode_fixed_size_frame(
     stream_info: &StreamInfo,
 ) -> Result<Frame, EncodeError> {
     let block_size = framebuf.size();
-    if block_size < MIN_BLOCKSIZE {
+    if block_size < MIN_BLOCK_SIZE {
         return Err(VerifyError::new(
             "input.framebuf.size",
-            &format!("must be greater than or equal to {MIN_BLOCKSIZE}"),
+            &format!("must be greater than or equal to {MIN_BLOCK_SIZE}"),
         )
         .into());
     }
-    if block_size > MAX_BLOCKSIZE {
+    if block_size > MAX_BLOCK_SIZE {
         return Err(VerifyError::new(
             "input.framebuf.size",
-            &format!("must be lesser than or equal to {MAX_BLOCKSIZE}"),
+            &format!("must be lesser than or equal to {MAX_BLOCK_SIZE}"),
         )
         .into());
     }

--- a/src/component.rs
+++ b/src/component.rs
@@ -30,10 +30,10 @@ use super::constant::qlpc::MAX_PRECISION as MAX_LPC_PRECISION;
 use super::constant::qlpc::MAX_SHIFT as MAX_LPC_SHIFT;
 use super::constant::qlpc::MIN_SHIFT as MIN_LPC_SHIFT;
 use super::constant::MAX_BITS_PER_SAMPLE;
-use super::constant::MAX_BLOCKSIZE;
+use super::constant::MAX_BLOCK_SIZE;
 use super::constant::MAX_CHANNELS;
 use super::constant::MIN_BITS_PER_SAMPLE;
-use super::constant::MIN_BLOCKSIZE;
+use super::constant::MIN_BLOCK_SIZE;
 use super::error::verify_range;
 use super::error::verify_true;
 use super::error::OutputError;
@@ -179,7 +179,7 @@ const fn block_size_spec(block_size: u16) -> (u8, u16, usize) {
 // Some (internal) utility macros for value verification.
 macro_rules! verify_block_size {
     ($varname:literal, $size:expr) => {
-        verify_range!($varname, $size, MIN_BLOCKSIZE..=MAX_BLOCKSIZE)
+        verify_range!($varname, $size, MIN_BLOCK_SIZE..=MAX_BLOCK_SIZE)
     };
 }
 macro_rules! verify_bps {

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,9 +61,9 @@ use super::constant::qlpc::MAX_ORDER as MAX_LPC_ORDER;
 use super::constant::qlpc::MAX_PRECISION as QLPC_MAX_PRECISION;
 use super::constant::rice::MAX_RICE_PARAMETER;
 use super::constant::DEFAULT_ENTROPY_ESTIMATOR_PARTITIONS;
-use super::constant::MAX_BLOCKSIZE;
+use super::constant::MAX_BLOCK_SIZE;
 use super::constant::MAX_ENTROPY_ESTIMATOR_PARTITIONS;
-use super::constant::MIN_BLOCKSIZE;
+use super::constant::MIN_BLOCK_SIZE;
 use super::error::verify_range;
 use super::error::verify_true;
 use super::error::Verify;
@@ -119,7 +119,7 @@ impl Verify for Encoder {
         )?;
 
         for (i, &bs) in self.block_sizes.iter().enumerate() {
-            verify_range!("block_sizes[{i}]", bs, MIN_BLOCKSIZE..=MAX_BLOCKSIZE)?;
+            verify_range!("block_sizes[{i}]", bs, MIN_BLOCK_SIZE..=MAX_BLOCK_SIZE)?;
         }
 
         self.stereo_coding

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -28,10 +28,10 @@ mod built {
 }
 
 /// Minimum length of a block supported.
-pub const MIN_BLOCKSIZE: usize = 64;
+pub const MIN_BLOCK_SIZE: usize = 64;
 
 /// Maximum length of a block supported (65535 in the specification.)
-pub const MAX_BLOCKSIZE: usize = 32767;
+pub const MAX_BLOCK_SIZE: usize = 32767;
 
 /// Maximum number of channels.
 pub const MAX_CHANNELS: usize = 8;


### PR DESCRIPTION
This is for consistency with other part of code.