### PR TITLE
Implement generic precision LPC and change to use f64.

### DIFF
--- a/report/report.nightly.md
+++ b/report/report.nightly.md
@@ -13,22 +13,22 @@ Sources used: wikimedia.i_love_you_california, wikimedia.jazz_funk_no1_sax, wiki
     - opt5: 0.5327653441525432
 
   - Ours
-    - default: 0.5413548751574235
-    - mt1: 0.5413548751574235
-    - st: 0.5413548751574235
-    - experimental: 0.5398606914598542
+    - default: 0.5319804533726037
+    - mt1: 0.5319804533726037
+    - st: 0.5319804533726037
+    - experimental: 0.5397906286725674
 
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 270.51983731528264
-    - opt8: 269.48562942412343
-    - opt5: 592.6467550756809
+    - opt8lax: 265.7696538906242
+    - opt8: 269.7046448210166
+    - opt5: 596.8032703123909
 
   - Ours
-    - default: 1588.970355867817
-    - mt1: 309.7851710713777
-    - st: 295.23939309091486
-    - experimental: 480.954495778942
+    - default: 1542.680967409842
+    - mt1: 289.2566651819286
+    - st: 275.6166209937488
+    - experimental: 483.29304309110614
 
 

--- a/report/report.stable.md
+++ b/report/report.stable.md
@@ -13,22 +13,22 @@ Sources used: wikimedia.i_love_you_california, wikimedia.jazz_funk_no1_sax, wiki
     - opt5: 0.5327653441525432
 
   - Ours
-    - default: 0.5413548751574235
-    - mt1: 0.5413548751574235
-    - st: 0.5413548751574235
-    - experimental: 0.5398606914598542
+    - default: 0.5337465985356039
+    - mt1: 0.5337465985356039
+    - st: 0.5337465985356039
+    - experimental: 0.5397919047270185
 
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 266.29154069730964
-    - opt8: 268.53693368680376
-    - opt5: 592.1588891502217
+    - opt8lax: 257.4397968610522
+    - opt8: 271.510899146056
+    - opt5: 607.9861997183116
 
   - Ours
-    - default: 1005.5740015255468
-    - mt1: 182.8543185466421
-    - st: 173.12734892350898
-    - experimental: 288.96337786378757
+    - default: 895.9928891341724
+    - mt1: 175.80962526355137
+    - st: 166.67643949962172
+    - experimental: 333.5738912123335
 
 

--- a/src/coding.rs
+++ b/src/coding.rs
@@ -46,6 +46,8 @@ use super::source::Context;
 use super::source::FrameBuf;
 use super::source::Source;
 
+use num_traits::AsPrimitive;
+
 import_simd!(as simd);
 
 /// Computes rice encoding of a scalar (used in `encode_residual`.)
@@ -346,6 +348,9 @@ fn perform_qlpc(
         }
     } else {
         lpc::lpc_from_autocorr(signal, &config.qlpc.window, config.qlpc.lpc_order)
+            .into_iter()
+            .map(AsPrimitive::as_)
+            .collect()
     }
 }
 

--- a/src/fakesimd.rs
+++ b/src/fakesimd.rs
@@ -119,6 +119,17 @@ impl SimdElement for f32 {
     }
 }
 
+impl SimdElement for f64 {
+    type Mask = Self;
+
+    fn simd_element_add(self, rhs: Self) -> Self {
+        self + rhs
+    }
+    fn simd_element_sub(self, rhs: Self) -> Self {
+        self - rhs
+    }
+}
+
 pub trait SupportedLaneCount {}
 pub struct LaneCount<const LANES: usize>();
 impl SupportedLaneCount for LaneCount<1> {}


### PR DESCRIPTION
Currently this is only done for auto-correlation method. The experimental covariance method is still done in f32.