### PR TITLE
Introduced accumulator type generics covariance-based LPC.

### DIFF
--- a/report/report.nightly.md
+++ b/report/report.nightly.md
@@ -13,22 +13,22 @@ Sources used: wikimedia.i_love_you_california, wikimedia.jazz_funk_no1_sax, wiki
     - opt5: 0.5327653441525432
 
   - Ours
-    - default: 0.5319804533726037
-    - mt1: 0.5319804533726037
-    - st: 0.5319804533726037
-    - experimental: 0.5397906286725674
+    - default: 0.5319834856477456
+    - mt1: 0.5319834856477456
+    - st: 0.5319834856477456
+    - experimental: 0.534068879533098
 
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 265.7696538906242
-    - opt8: 269.7046448210166
-    - opt5: 596.8032703123909
+    - opt8lax: 266.5557798147213
+    - opt8: 271.78071886046257
+    - opt5: 599.1597278883653
 
   - Ours
-    - default: 1542.680967409842
-    - mt1: 289.2566651819286
-    - st: 275.6166209937488
-    - experimental: 483.29304309110614
+    - default: 1510.3708064193834
+    - mt1: 287.41096468484125
+    - st: 276.5189927783642
+    - experimental: 419.11238054389776
 
 

--- a/report/report.stable.md
+++ b/report/report.stable.md
@@ -13,22 +13,22 @@ Sources used: wikimedia.i_love_you_california, wikimedia.jazz_funk_no1_sax, wiki
     - opt5: 0.5327653441525432
 
   - Ours
-    - default: 0.5337465985356039
-    - mt1: 0.5337465985356039
-    - st: 0.5337465985356039
-    - experimental: 0.5397919047270185
+    - default: 0.5337451175150131
+    - mt1: 0.5337451175150131
+    - st: 0.5337451175150131
+    - experimental: 0.5341182229762562
 
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 257.4397968610522
-    - opt8: 271.510899146056
-    - opt5: 607.9861997183116
+    - opt8lax: 263.3023896855921
+    - opt8: 270.18574629553854
+    - opt5: 572.7666214688647
 
   - Ours
-    - default: 895.9928891341724
-    - mt1: 175.80962526355137
-    - st: 166.67643949962172
-    - experimental: 333.5738912123335
+    - default: 840.8676360800642
+    - mt1: 151.28175553093172
+    - st: 145.96496704404677
+    - experimental: 265.4066564279058
 
 

--- a/src/coding.rs
+++ b/src/coding.rs
@@ -46,8 +46,6 @@ use super::source::Context;
 use super::source::FrameBuf;
 use super::source::Source;
 
-use num_traits::AsPrimitive;
-
 import_simd!(as simd);
 
 /// Computes rice encoding of a scalar (used in `encode_residual`.)
@@ -334,7 +332,7 @@ fn fixed_lpc(
 fn perform_qlpc(
     config: &config::SubFrameCoding,
     signal: &[i32],
-) -> heapless::Vec<f32, MAX_LPC_ORDER> {
+) -> heapless::Vec<f64, MAX_LPC_ORDER> {
     if config.qlpc.use_direct_mse {
         if config.qlpc.mae_optimization_steps > 0 {
             lpc::lpc_with_irls_mae(
@@ -348,9 +346,6 @@ fn perform_qlpc(
         }
     } else {
         lpc::lpc_from_autocorr(signal, &config.qlpc.window, config.qlpc.lpc_order)
-            .into_iter()
-            .map(AsPrimitive::as_)
-            .collect()
     }
 }
 


### PR DESCRIPTION
In fact, this makes a visible degradation in computational performance with "experimental" configuration. However, since it is anyway important to have freedom in choice of accumulator type in LPC, the regression is accepted.