### PR TITLE
Tuned parameters.

### DIFF
--- a/report/experimental.config.toml
+++ b/report/experimental.config.toml
@@ -6,8 +6,6 @@
 # feature is intended to be used for providing a reference data points when
 # tuning window functions.
 
-block_sizes = [2048]
-
 [subframe_coding.qlpc]
 use_direct_mse = true
 

--- a/report/report.nightly.md
+++ b/report/report.nightly.md
@@ -13,22 +13,22 @@ Sources used: wikimedia.i_love_you_california, wikimedia.jazz_funk_no1_sax, wiki
     - opt5: 0.5327653441525432
 
   - Ours
-    - default: 0.5319834856477456
-    - mt1: 0.5319834856477456
-    - st: 0.5319834856477456
-    - experimental: 0.534068879533098
+    - default: 0.5276598659672681
+    - mt1: 0.5276598659672681
+    - st: 0.5276598659672681
+    - experimental: 0.529737562490126
 
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 266.5557798147213
-    - opt8: 271.78071886046257
-    - opt5: 599.1597278883653
+    - opt8lax: 266.9645261484993
+    - opt8: 269.65352590082045
+    - opt5: 606.6012986385526
 
   - Ours
-    - default: 1510.3708064193834
-    - mt1: 287.41096468484125
-    - st: 276.5189927783642
-    - experimental: 419.11238054389776
+    - default: 1564.2182133790025
+    - mt1: 286.32151855792284
+    - st: 275.91639025116854
+    - experimental: 289.14667950935365
 
 

--- a/report/report.stable.md
+++ b/report/report.stable.md
@@ -13,22 +13,22 @@ Sources used: wikimedia.i_love_you_california, wikimedia.jazz_funk_no1_sax, wiki
     - opt5: 0.5327653441525432
 
   - Ours
-    - default: 0.5337451175150131
-    - mt1: 0.5337451175150131
-    - st: 0.5337451175150131
-    - experimental: 0.5341182229762562
+    - default: 0.5290486730982896
+    - mt1: 0.5290486730982896
+    - st: 0.5290486730982896
+    - experimental: 0.5297100446766292
 
 
 ### Average compression speed (inverse RTF)
   - Reference
-    - opt8lax: 263.3023896855921
-    - opt8: 270.18574629553854
-    - opt5: 572.7666214688647
+    - opt8lax: 262.11032504464407
+    - opt8: 269.28001537071754
+    - opt5: 595.8426525071836
 
   - Ours
-    - default: 840.8676360800642
-    - mt1: 151.28175553093172
-    - st: 145.96496704404677
-    - experimental: 265.4066564279058
+    - default: 822.9824726775479
+    - mt1: 152.6344756652568
+    - st: 146.4867583688406
+    - experimental: 265.6082361221588
 
 

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -114,10 +114,10 @@ pub mod qlpc {
     pub const DEFAULT_ORDER: usize = 10;
 
     /// Default precision for storing QLPC coefficients.
-    pub const DEFAULT_PRECISION: usize = 12;
+    pub const DEFAULT_PRECISION: usize = 15;
 
     /// Default alpha parameter for Tukey window.
-    pub const DEFAULT_TUKEY_ALPHA: f32 = 0.1;
+    pub const DEFAULT_TUKEY_ALPHA: f32 = 0.4;
 }
 
 /// Constants related to partitioned rice coding (PRC).


### PR DESCRIPTION
This commit also changes how covariance-based LPC increases regularization terms to be consistent with the one used for auto-correlation-based LPC.