### PR TITLE
Block size configuration is now scalar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ let config = flacenc::config::Encoder::default().into_verified().expect(
 let source = flacenc::source::MemSource::from_samples(
     samples, channels, bits_per_sample, sample_rate);
 let flac_stream = flacenc::encode_with_fixed_block_size(
-    &config, source, config.block_sizes[0]
+    &config, source, config.block_size
 ).expect("Encode failed.");
 
 // `Stream` imlpements `BitRepr` so you can obtain the encoded stream via

--- a/flacenc-bin/src/main.rs
+++ b/flacenc-bin/src/main.rs
@@ -115,8 +115,7 @@ fn run_encoder<S: Source>(
     encoder_config: &Verified<config::Encoder>,
     source: S,
 ) -> Result<Stream, EncodeError> {
-    let block_size = encoder_config.block_sizes[0];
-    flacenc::encode_with_fixed_block_size(encoder_config, source, block_size)
+    flacenc::encode_with_fixed_block_size(encoder_config, source, encoder_config.block_size)
 }
 
 fn log_build_constants() {

--- a/fuzz/fuzz_targets/frame_encode.rs
+++ b/fuzz/fuzz_targets/frame_encode.rs
@@ -49,7 +49,7 @@ fn arbitrary_config(
     block_size: usize,
 ) -> Result<Verified<config::Encoder>, arbitrary::Error> {
     let mut config = config::Encoder::default();
-    config.block_sizes = vec![block_size];
+    config.block_size = block_size;
     config.stereo_coding.use_leftside = bool::arbitrary(u)?;
     config.stereo_coding.use_rightside = bool::arbitrary(u)?;
     config.stereo_coding.use_midside = bool::arbitrary(u)?;

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -28,6 +28,9 @@ mod built {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
 
+/// Default block size.
+pub const DEFAULT_BLOCK_SIZE: usize = 4096;
+
 /// Minimum length of a block supported.
 pub const MIN_BLOCK_SIZE: usize = 64;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,7 +226,7 @@ multithread = false
 
         test_helper::integrity_test(
             |s| {
-                coding::encode_with_fixed_block_size(&config, s, config.block_sizes[0])
+                coding::encode_with_fixed_block_size(&config, s, config.block_size)
                     .expect("source error")
             },
             &source,


### PR DESCRIPTION
It was a vector for a historical reason. We first wanted to support variable block size encoding, but so far we don't see any improvement by using multiple block sizes. Now it is removed, and if we revisit multiple block sizes again, this field should be used as a "primary" block size and we should add another field for this purpose.