### PR TITLE
Fixed encoder error when encoding WAV 8/24-bit input.

### DIFF
--- a/flacenc-bin/Cargo.lock
+++ b/flacenc-bin/Cargo.lock
@@ -374,6 +374,7 @@ dependencies = [
  "flacenc",
  "hound",
  "log",
+ "md-5",
  "pprof",
  "rmp-serde",
  "rstest",

--- a/flacenc-bin/Cargo.toml
+++ b/flacenc-bin/Cargo.toml
@@ -38,7 +38,9 @@ pprof = { version = "0.13", features = [
   "flamegraph",
   "protobuf-codec",
 ], optional = true }
+md-5 = "0.10.6"
 rmp-serde = "1.1.2"
+tempfile = "3"
 termcolor = "1.4"
 toml = "0.8.10"
 
@@ -49,5 +51,4 @@ simd-nightly = ["flacenc/simd-nightly"]
 
 [dev-dependencies]
 flacenc = { version = "0.5.0", path = "..", features = ["__export_sigen"] }
-tempfile = "3"
 rstest = "0.22"

--- a/flacenc-bin/src/source.rs
+++ b/flacenc-bin/src/source.rs
@@ -115,6 +115,12 @@ impl Source for HoundSource {
             .map_err(SourceError::from_io_error)?;
 
         self.current_offset += to_read;
+        if self.bytes_per_sample == 1 {
+            // 8-bit wav is not in two's complement, so convert it first
+            self.bytebuf.iter_mut().for_each(|p| {
+                *p = (i32::from(*p) - 128).to_le_bytes()[0];
+            });
+        }
         dest.fill_le_bytes(&self.bytebuf, self.bytes_per_sample)?;
 
         Ok(read_bytes / self.channels() / self.bytes_per_sample)

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "flacenc"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "built",
  "crc",

--- a/src/arrayutils.rs
+++ b/src/arrayutils.rs
@@ -368,7 +368,7 @@ pub fn le_bytes_to_i32s(bytes: &[u8], dest: &mut [i32], bytes_per_sample: usize)
 /// Converts i32s to little-endian bytes.
 ///
 /// NOTE: Currenty, this function is not used in "flacenc-bin", and therefore
-/// this might be slow.
+/// the performance is not checked recently, might be too slow.
 #[allow(dead_code)] // only used in unittests with `cfg(features = "serde")`.
 pub fn i32s_to_le_bytes(ints: &[i32], dest: &mut [u8], bytes_per_sample: usize) {
     let mut n = 0;
@@ -739,6 +739,14 @@ mod tests {
         let mut dest = [0i32; 4];
         le_bytes_to_i32s(&bytes, &mut dest, 3);
         assert_eq!(dest, [0x12_3456, 0x13_579B, -1, 0x24_68AC]);
+    }
+
+    #[test]
+    fn convert_bytes_to_i8s() {
+        let bytes = [0x56, 0x34, 0x12, 0x9B, 0x80, 0x13, 0xFF, 0x68];
+        let mut dest = [0i32; 8];
+        le_bytes_to_i32s(&bytes, &mut dest, 1);
+        assert_eq!(dest, [0x56, 0x34, 0x12, -0x65, -0x80, 0x13, -0x01, 0x68]);
     }
 
     #[cfg(feature = "simd-nightly")]

--- a/src/component/parser.rs
+++ b/src/component/parser.rs
@@ -421,7 +421,7 @@ pub fn subframe<'a, E>(
 where
     E: ParseError<BitInput<'a>>,
 {
-    debug_assert!(bits_per_sample <= MAX_BITS_PER_SAMPLE);
+    debug_assert!(bits_per_sample <= MAX_BITS_PER_SAMPLE + 1);
     alt((
         into(constant::<E>(block_size, bits_per_sample)),
         into(fixed_lpc::<E>(block_size, bits_per_sample)),
@@ -456,7 +456,7 @@ pub fn constant<'a, E>(
 where
     E: ParseError<BitInput<'a>>,
 {
-    debug_assert!(bits_per_sample <= MAX_BITS_PER_SAMPLE);
+    debug_assert!(bits_per_sample <= MAX_BITS_PER_SAMPLE + 1);
     move |input| {
         let remaining_input = input;
         let (remaining_input, (typetag, _wasted_flag)) = subframe_header(remaining_input)?;
@@ -493,7 +493,7 @@ pub fn fixed_lpc<'a, E>(
 where
     E: ParseError<BitInput<'a>>,
 {
-    debug_assert!(bits_per_sample <= MAX_BITS_PER_SAMPLE);
+    debug_assert!(bits_per_sample <= MAX_BITS_PER_SAMPLE + 1);
     move |input| {
         let remaining_input = input;
         let (remaining_input, (typetag, _wasted_flag)) = subframe_header(remaining_input)?;
@@ -532,7 +532,7 @@ pub fn lpc<'a, E>(
 where
     E: ParseError<BitInput<'a>>,
 {
-    debug_assert!(bits_per_sample <= MAX_BITS_PER_SAMPLE);
+    debug_assert!(bits_per_sample <= MAX_BITS_PER_SAMPLE + 1);
     move |input| {
         let remaining_input = input;
         let (remaining_input, (typetag, _wasted_flag)) = subframe_header(remaining_input)?;
@@ -598,7 +598,7 @@ pub fn verbatim<'a, E>(
 where
     E: ParseError<BitInput<'a>>,
 {
-    debug_assert!(bits_per_sample <= MAX_BITS_PER_SAMPLE);
+    debug_assert!(bits_per_sample <= MAX_BITS_PER_SAMPLE + 1);
     move |input| {
         let remaining_input = input;
         let (remaining_input, (typetag, _wasted_flag)) = subframe_header(remaining_input)?;
@@ -703,7 +703,7 @@ fn raw_samples<'a, E>(
 where
     E: ParseError<BitInput<'a>>,
 {
-    debug_assert!(bits_per_sample <= MAX_BITS_PER_SAMPLE);
+    debug_assert!(bits_per_sample <= MAX_BITS_PER_SAMPLE + 1);
     move |input| {
         let mut remaining_input = input;
         let mut data = Vec::with_capacity(size);


### PR DESCRIPTION
By specification, WAV file stores numbers in unsigned format with some offset values added when bits-per-sample is less than (or equal to) 8.

For 24-bit, some parser functions had assert-statement to verify `bits_per_sample <= MAX_BITS_PER_SAMPLE` that is 24. However, this assumption is wrong for `SubFrames` of side-channels.

For fixing this bug, this commits does:
1. perform u8+offset to i8 in `HoundSource`.
2. MD5 check is introduced to "flacenc-bin"
3. integration test now can output intermediate file to a specified directory for debugging.
4. a test added for `arrayutils::le_bytes_to_i32s` (found out not to be a bug of this function, though)
5. changed assert-statement to check `bits_per_sample <= MAX_BITS_PER_SAMPLE + 1`