### PR TITLE
Update docs, and hide `MetadataBlock` from API

### DIFF
--- a/src/arrayutils.rs
+++ b/src/arrayutils.rs
@@ -64,7 +64,6 @@ where
 
     /// Returns the number of internal simd-vectors.
     #[inline]
-    #[allow(dead_code)]
     pub fn simd_len(&self) -> usize {
         self.inner.len()
     }
@@ -119,7 +118,6 @@ where
 
     /// Returns a slice of the simd vectors.
     #[inline]
-    #[allow(dead_code)]
     pub fn as_ref_simd(&self) -> &[simd::Simd<T, N>] {
         &self.inner
     }

--- a/src/component.rs
+++ b/src/component.rs
@@ -31,7 +31,7 @@ pub use datatype::Frame;
 pub use datatype::FrameHeader;
 pub use datatype::FrameOffset;
 pub use datatype::Lpc;
-pub use datatype::MetadataBlock;
+pub(crate) use datatype::MetadataBlock;
 pub use datatype::MetadataBlockData;
 pub use datatype::QuantizedParameters;
 pub use datatype::Residual;

--- a/src/component/parser.rs
+++ b/src/component/parser.rs
@@ -42,6 +42,12 @@ type BitInput<'a> = (&'a [u8], usize);
 
 /// Recognizes [`component::Stream`].
 ///
+/// # Examples
+///
+/// ```
+///
+/// ```
+///
 /// # Errors
 ///
 /// Same as other nom parsers, this returns [`nom::Err`] if `input` doesn't conforms the format.
@@ -87,10 +93,13 @@ where
 
 /// Recognizes [`component::MetadataBlock`].
 ///
+/// This parser is intentionally hidden from public API because [`metadata_block_data`] already
+/// provides full-control over the components.
+///
 /// # Errors
 ///
 /// Same as other nom parsers, this returns [`nom::Err`] if `input` doesn't conforms the format.
-pub fn metadata_block<'a, E>(input: &'a [u8]) -> IResult<&'a [u8], component::MetadataBlock, E>
+fn metadata_block<'a, E>(input: &'a [u8]) -> IResult<&'a [u8], component::MetadataBlock, E>
 where
     E: ParseError<&'a [u8]>,
 {


### PR DESCRIPTION
`MetadataBlock` is an intermediate object that only holds the type tag and a flag indicating whether the block is last block in stream, or not. So API-wise, this has no meaning to be exposed.