### PR TITLE
Due to some operational mistakes, flacenc-bin is rebumped to v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-## 0.5.0 (flacenc-bin: 0.2.5)
+## 0.5.0 (flacenc-bin: 0.2.6)
 
 ### Breaking Changes
 

--- a/flacenc-bin/Cargo.toml
+++ b/flacenc-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flacenc-bin"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Yotaro Kubo <yotaro@ieee.org>"]
 description = "FLAC encoder written in pure Rust. An example application for flacenc crate."
 readme = "README.md"


### PR DESCRIPTION
Previous release (v0.2.5, which is already yanked) was not containing the latest updates.