### PR TITLE
Use latest `built` (and unpin the version)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,4 @@ tempfile = "3"
 toml = "0.5"
 
 [build-dependencies]
-built = "=0.7.1"
+built = "0.7.7"


### PR DESCRIPTION
This fixes the issue described in #238.

I fixed this in my fork so that I can continue working. If you do not agree with this solution, then feel free to close. I just wanted to extend this PR in case you find it useful. Thanks!