### PR TITLE
Add RESIDUAL_CODING_METHOD_PARTITIONED_RICE2 support

### DIFF
--- a/src/coding.rs
+++ b/src/coding.rs
@@ -394,18 +394,18 @@ fn encode_subframe(
         // Assuming constant is always best if it's applicable.
         Constant::from_parts(samples.len(), samples[0], bits_per_sample).into()
     } else {
-        let baseline_bits =
+        let verbatim_bits =
             Verbatim::count_bits_from_metadata(samples.len(), bits_per_sample as usize);
 
         let too_short = samples.len() < MIN_BLOCK_SIZE_FOR_PREDICTION;
         let fixed = if !too_short && config.use_fixed {
-            fixed_lpc(config, samples, bits_per_sample, baseline_bits)
+            fixed_lpc(config, samples, bits_per_sample, verbatim_bits)
         } else {
             None
         };
 
-        let baseline_bits = fixed.as_ref().map_or(baseline_bits, |x| {
-            std::cmp::min(baseline_bits, x.count_bits())
+        let baseline_bits = fixed.as_ref().map_or(verbatim_bits, |x| {
+            std::cmp::min(verbatim_bits, x.count_bits())
         });
         let est_lpc = if !too_short && config.use_lpc {
             let candidate = estimated_qlpc(config, samples, bits_per_sample);
@@ -416,6 +416,7 @@ fn encode_subframe(
 
         est_lpc
             .or(fixed)
+            .filter(|sf| sf.count_bits() < verbatim_bits)
             .unwrap_or_else(|| Verbatim::from_samples(samples, bits_per_sample).into())
     }
 }

--- a/src/component/bitrepr.rs
+++ b/src/component/bitrepr.rs
@@ -537,7 +537,10 @@ impl BitRepr for Residual {
         let mut remainder_bits: usize =
             self.sum_rice_params() * (self.block_size() >> self.partition_order());
         remainder_bits -= self.warmup_length() * self.rice_params()[0] as usize;
-        2 + 4 + nparts * 4 + quotient_bits + remainder_bits
+        // Use RICE2 (5-bit params) when any parameter exceeds 14
+        let use_rice2 = self.rice_params().iter().any(|&p| p > 14);
+        let param_bits = if use_rice2 { 5 } else { 4 };
+        2 + 4 + nparts * param_bits + quotient_bits + remainder_bits
     }
 
     /// Writes `Residual` to the [`BitSink`].
@@ -545,10 +548,15 @@ impl BitRepr for Residual {
     /// This is the most inner-loop of the output part of the encoder, so
     /// computational efficiency is prioritized more than readability.
     fn write<S: BitSink>(&self, dest: &mut S) -> Result<(), OutputError<S>> {
-        // The number of partitions with 00 (indicating 4-bit mode) prepended.
-        dest.write_lsbs(self.partition_order() as u32, 6)
-            .map_err(OutputError::<S>::from_sink)?;
         let nparts = 1usize << self.partition_order();
+        // Use RICE2 (5-bit params) when any parameter exceeds 14
+        let use_rice2 = self.rice_params()[..nparts].iter().any(|&p| p > 14);
+        let (method_bits, param_bits): (u32, usize) = if use_rice2 { (1, 5) } else { (0, 4) };
+
+        // Write method (2 bits) + partition order (4 bits) = 6 bits total
+        let header = (method_bits << 4) | (self.partition_order() as u32);
+        dest.write_lsbs(header, 6)
+            .map_err(OutputError::<S>::from_sink)?;
 
         // unforunatelly, the overhead due to the use of iterators is visible
         // here. so we back-off to integer-based loops. (drawback of index-loop
@@ -558,7 +566,7 @@ impl BitRepr for Residual {
         let mut offset = 0;
         while p < nparts {
             let rice_p = self.rice_params()[p];
-            dest.write_lsbs(rice_p, 4)
+            dest.write_lsbs(rice_p, param_bits)
                 .map_err(OutputError::<S>::from_sink)?;
             let start = max(self.warmup_length(), offset);
             offset += part_len;

--- a/src/config.rs
+++ b/src/config.rs
@@ -492,7 +492,7 @@ mod tests {
         }
         {
             let config = Prc {
-                max_parameter: 18,
+                max_parameter: 31,
                 ..Default::default()
             };
             config.verify().unwrap_err();

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -138,9 +138,9 @@ pub mod qlpc {
 pub mod rice {
     /// Maximum allowed value for the Rice parameters.
     ///
-    /// 5-bit rice coding is not supported currently, and 0b1111 is reserved for
-    /// verbatim encoding. So, 14 will be the maximum.
-    pub const MAX_RICE_PARAMETER: usize = 14;
+    /// With 5-bit rice coding (RICE2), the maximum parameter is 30
+    /// (0b11111 = 31 is reserved for escape/verbatim).
+    pub const MAX_RICE_PARAMETER: usize = 30;
 
     /// Maximum order of Rice parameter partitioning.
     pub const MAX_PARTITION_ORDER: usize = 15;

--- a/src/rice.rs
+++ b/src/rice.rs
@@ -25,17 +25,22 @@ use super::repeat::repeat;
 import_simd!(as simd);
 
 /// Table that contains the numbers of bits needed for a partition.
+/// Supports rice parameters 0..=30 using two 16-wide SIMD vectors.
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
-#[repr(transparent)]
 struct PrcBitTable {
-    p_to_bits: simd::u32x16,
+    p_to_bits_lo: simd::u32x16,  // params 0..15
+    p_to_bits_hi: simd::u32x16,  // params 16..31
 }
 
 static ZEROS: simd::u32x16 = simd::u32x16::from_array([0u32; 16]);
 static INDEX: simd::u32x16 =
     simd::u32x16::from_array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+static INDEX_HI: simd::u32x16 =
+    simd::u32x16::from_array([16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]);
 static INDEX1: simd::u32x16 =
     simd::u32x16::from_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+static INDEX1_HI: simd::u32x16 =
+    simd::u32x16::from_array([17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]);
 static MAXES: simd::u32x16 = simd::u32x16::from_array([u32::MAX; 16]);
 
 // max value of p_to_bits is chosen so that an estimate doesn't overflow after
@@ -48,71 +53,90 @@ const PRC_BIT_TABLE_FROM_ERRORS_UNROLL_N: usize = 16; // must be up to 16.
 impl PrcBitTable {
     #[cfg(test)]
     pub fn zero() -> Self {
-        Self { p_to_bits: ZEROS }
+        Self { p_to_bits_lo: ZEROS, p_to_bits_hi: ZEROS }
     }
 
     pub fn from_errors(errors: &[u32], offset: usize) -> Self {
         // ensure that there's no overflow.
         debug_assert!(offset < (1 << 31));
-        let offset =
+        let offset_lo =
             simd::u32x16::splat(offset as u32) + simd::u32x16::splat(errors.len() as u32) * INDEX1;
-        let mut p_to_bits = ZEROS;
+        let offset_hi =
+            simd::u32x16::splat(offset as u32) + simd::u32x16::splat(errors.len() as u32) * INDEX1_HI;
+        let mut p_to_bits_lo = ZEROS;
+        let mut p_to_bits_hi = ZEROS;
 
-        // MAX_P_TO_BITS is designed not to overflow after 16 times of addition.
-        //
-        // TODO: there's still a risk of overflow when there's a consecutive 16
-        // elements in `error` where all are larger than `1 << 28`. Since it's
-        // very low probability and clamping inputs may degrade the performance,
-        // this issue is ignored currently.
-        //
-        // In most of SIMD-capable CPUs, saturating ops can be done with a
-        // single instruction. However, strangely the use of `saturating_add`
-        // and removing `simd_min` from the loop actually slowed down the
-        // computation by almost twice.
         for chunk in errors.chunks(PRC_BIT_TABLE_FROM_ERRORS_UNROLL_N) {
             if chunk.len() == PRC_BIT_TABLE_FROM_ERRORS_UNROLL_N {
                 repeat!(n to PRC_BIT_TABLE_FROM_ERRORS_UNROLL_N => {
-                    p_to_bits += simd::Simd::splat(chunk[n]) >> INDEX;
+                    let v = simd::Simd::splat(chunk[n]);
+                    p_to_bits_lo += v >> INDEX;
+                    p_to_bits_hi += v >> INDEX_HI;
                 });
             } else {
                 repeat!(
                     n to PRC_BIT_TABLE_FROM_ERRORS_UNROLL_N;
                     while n < chunk.len() => {
-                        p_to_bits += simd::Simd::splat(chunk[n]) >> INDEX;
+                        let v = simd::Simd::splat(chunk[n]);
+                        p_to_bits_lo += v >> INDEX;
+                        p_to_bits_hi += v >> INDEX_HI;
                     }
                 );
             }
-            p_to_bits = p_to_bits.simd_min(MAX_P_TO_BITS_VEC);
+            p_to_bits_lo = p_to_bits_lo.simd_min(MAX_P_TO_BITS_VEC);
+            p_to_bits_hi = p_to_bits_hi.simd_min(MAX_P_TO_BITS_VEC);
         }
-        p_to_bits += offset;
-        p_to_bits = p_to_bits.simd_min(MAX_P_TO_BITS_VEC);
-        Self { p_to_bits }
+        p_to_bits_lo += offset_lo;
+        p_to_bits_lo = p_to_bits_lo.simd_min(MAX_P_TO_BITS_VEC);
+        p_to_bits_hi += offset_hi;
+        p_to_bits_hi = p_to_bits_hi.simd_min(MAX_P_TO_BITS_VEC);
+        Self { p_to_bits_lo, p_to_bits_hi }
     }
 
     #[cfg(test)]
     pub fn bits(&self, p: usize) -> usize {
-        self.p_to_bits[p] as usize
+        if p < 16 {
+            self.p_to_bits_lo[p] as usize
+        } else {
+            self.p_to_bits_hi[p - 16] as usize
+        }
     }
 
     #[inline]
     pub fn minimizer(&self, max_p: usize) -> (usize, usize) {
         debug_assert!(max_p <= MAX_RICE_PARAMETER);
-        // exploit the fact that `p_to_bits` only occupies 28-bits of u32.
-        let mask = INDEX.simd_le(simd::u32x16::splat(max_p as u32));
-        let four = simd::u32x16::splat(4);
-        let packed_bits_and_idxs = (mask.select(self.p_to_bits, MAXES) << four) | INDEX;
-        let minim = packed_bits_and_idxs.reduce_min();
-        let ret_bits = minim >> 4;
-        let ret_p = minim & 0x0F;
 
-        (ret_p as usize, ret_bits as usize)
+        // Search low half (params 0..15)
+        let five = simd::u32x16::splat(5);
+
+        let lo_max = std::cmp::min(max_p, 15);
+        let mask_lo = INDEX.simd_le(simd::u32x16::splat(lo_max as u32));
+        let packed_lo = (mask_lo.select(self.p_to_bits_lo, MAXES) << five) | INDEX;
+        let minim_lo = packed_lo.reduce_min();
+
+        if max_p > 15 {
+            // Also search high half (params 16..31)
+            let mask_hi = INDEX_HI.simd_le(simd::u32x16::splat(max_p as u32));
+            let packed_hi = (mask_hi.select(self.p_to_bits_hi, MAXES) << five) | INDEX_HI;
+            let minim_hi = packed_hi.reduce_min();
+
+            let minim = std::cmp::min(minim_lo, minim_hi);
+            let ret_bits = minim >> 5;
+            let ret_p = minim & 0x1F;
+            (ret_p as usize, ret_bits as usize)
+        } else {
+            let ret_bits = minim_lo >> 5;
+            let ret_p = minim_lo & 0x1F;
+            (ret_p as usize, ret_bits as usize)
+        }
     }
 
     #[inline]
     pub fn merge(&self, other: &Self, offset: usize) -> Self {
         let offset = simd::u32x16::splat(offset as u32);
         Self {
-            p_to_bits: self.p_to_bits + other.p_to_bits - offset,
+            p_to_bits_lo: self.p_to_bits_lo + other.p_to_bits_lo - offset,
+            p_to_bits_hi: self.p_to_bits_hi + other.p_to_bits_hi - offset,
         }
     }
 }
@@ -300,8 +324,8 @@ mod tests {
         let (p, _bits) = table.minimizer(max_p);
         eprintln!("Table = {table:?}");
         eprintln!("Found p = {p}");
-        // assert at least there's some parameter smaller than verbatim coding.
-        assert!(p < 13);
+        // assert at least there's some parameter smaller than max.
+        assert!(p < 29);
         // Also, must be better than unary coding.
         assert!(p > 0);
     }
@@ -335,9 +359,9 @@ mod tests {
     #[test]
     fn partition_evaluation() {
         let mut part1 = PrcBitTable::zero();
-        part1.p_to_bits[0..5].copy_from_slice(&[17, 19, 15, 11, 19]);
+        part1.p_to_bits_lo[0..5].copy_from_slice(&[17, 19, 15, 11, 19]);
         let mut part2 = PrcBitTable::zero();
-        part2.p_to_bits[0..5].copy_from_slice(&[12, 14, 16, 18, 20]);
+        part2.p_to_bits_lo[0..5].copy_from_slice(&[12, 14, 16, 18, 20]);
 
         let mut params = [0, 0];
         let min_bits = eval_partitions(&[part1, part2], &mut params, 4);
@@ -348,32 +372,32 @@ mod tests {
     #[test]
     fn partition_merging() {
         let mut part1 = PrcBitTable::zero();
-        part1.p_to_bits[0..5].copy_from_slice(&[17, 19, 15, 11, 19]);
+        part1.p_to_bits_lo[0..5].copy_from_slice(&[17, 19, 15, 11, 19]);
         let mut part2 = PrcBitTable::zero();
-        part2.p_to_bits[0..5].copy_from_slice(&[12, 14, 16, 18, 20]);
+        part2.p_to_bits_lo[0..5].copy_from_slice(&[12, 14, 16, 18, 20]);
 
         let mut table = [part1, part2];
         let table_size = merge_partitions(&mut table);
         assert_eq!(table_size, 1);
-        assert_eq!(table[0].p_to_bits[0..5], [25, 29, 27, 25, 35]);
+        assert_eq!(table[0].p_to_bits_lo[0..5], [25, 29, 27, 25, 35]);
     }
 
     #[test]
     fn minimizer_search() {
         let mut bt = PrcBitTable::zero();
-        bt.p_to_bits[0..8].copy_from_slice(&[6, 7, 4, 5, 9, 0, 0, 0]);
+        bt.p_to_bits_lo[0..8].copy_from_slice(&[6, 7, 4, 5, 9, 0, 0, 0]);
         assert_eq!(bt.minimizer(4), (2, 4));
 
         let mut bt = PrcBitTable::zero();
-        bt.p_to_bits[0..8].copy_from_slice(&[6, 7, 8, 5, 3, 0, 0, 0]);
+        bt.p_to_bits_lo[0..8].copy_from_slice(&[6, 7, 8, 5, 3, 0, 0, 0]);
         assert_eq!(bt.minimizer(4), (4, 3));
 
         let mut bt = PrcBitTable::zero();
-        bt.p_to_bits[0..8].copy_from_slice(&[1, 7, 8, 5, 3, 0, 0, 0]);
+        bt.p_to_bits_lo[0..8].copy_from_slice(&[1, 7, 8, 5, 3, 0, 0, 0]);
         assert_eq!(bt.minimizer(4), (0, 1));
 
         let mut bt = PrcBitTable::zero();
-        bt.p_to_bits[0..8].copy_from_slice(&[7, 1, 1, 1, 3, 0, 0, 0]);
+        bt.p_to_bits_lo[0..8].copy_from_slice(&[7, 1, 1, 1, 3, 0, 0, 0]);
         // Current implementation prefers the smallest p when there're multiple
         // minimizers.
         assert_eq!(bt.minimizer(4), (1, 1));

--- a/src/rice.rs
+++ b/src/rice.rs
@@ -45,7 +45,8 @@ static MAXES: simd::u32x16 = simd::u32x16::from_array([u32::MAX; 16]);
 
 // max value of p_to_bits is chosen so that an estimate doesn't overflow after
 // being added 2^4 = 16 times each other at maximum.
-static MAX_P_TO_BITS: u32 = (1 << 28) - 1;
+// With RICE2, minimizer packs bits with << 5, so max safe value is (1 << 27) - 1.
+static MAX_P_TO_BITS: u32 = (1 << 27) - 1;
 static MAX_P_TO_BITS_VEC: simd::u32x16 = simd::u32x16::from_array([MAX_P_TO_BITS; 16]);
 
 const PRC_BIT_TABLE_FROM_ERRORS_UNROLL_N: usize = 16; // must be up to 16.
@@ -135,8 +136,8 @@ impl PrcBitTable {
     pub fn merge(&self, other: &Self, offset: usize) -> Self {
         let offset = simd::u32x16::splat(offset as u32);
         Self {
-            p_to_bits_lo: self.p_to_bits_lo + other.p_to_bits_lo - offset,
-            p_to_bits_hi: self.p_to_bits_hi + other.p_to_bits_hi - offset,
+            p_to_bits_lo: (self.p_to_bits_lo + other.p_to_bits_lo - offset).simd_min(MAX_P_TO_BITS_VEC),
+            p_to_bits_hi: (self.p_to_bits_hi + other.p_to_bits_hi - offset).simd_min(MAX_P_TO_BITS_VEC),
         }
     }
 }
@@ -324,8 +325,8 @@ mod tests {
         let (p, _bits) = table.minimizer(max_p);
         eprintln!("Table = {table:?}");
         eprintln!("Found p = {p}");
-        // assert at least there's some parameter smaller than max.
-        assert!(p < 29);
+        // assert the optimizer found a reasonable parameter, not at the boundary.
+        assert!(p < max_p);
         // Also, must be better than unary coding.
         assert!(p > 0);
     }

--- a/src/rice.rs
+++ b/src/rice.rs
@@ -28,19 +28,21 @@ import_simd!(as simd);
 /// Supports rice parameters 0..=30 using two 16-wide SIMD vectors.
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 struct PrcBitTable {
-    p_to_bits_lo: simd::u32x16,  // params 0..15
-    p_to_bits_hi: simd::u32x16,  // params 16..31
+    p_to_bits_lo: simd::u32x16, // params 0..15
+    p_to_bits_hi: simd::u32x16, // params 16..31
 }
 
 static ZEROS: simd::u32x16 = simd::u32x16::from_array([0u32; 16]);
 static INDEX: simd::u32x16 =
     simd::u32x16::from_array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
-static INDEX_HI: simd::u32x16 =
-    simd::u32x16::from_array([16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]);
+static INDEX_HI: simd::u32x16 = simd::u32x16::from_array([
+    16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+]);
 static INDEX1: simd::u32x16 =
     simd::u32x16::from_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
-static INDEX1_HI: simd::u32x16 =
-    simd::u32x16::from_array([17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]);
+static INDEX1_HI: simd::u32x16 = simd::u32x16::from_array([
+    17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+]);
 static MAXES: simd::u32x16 = simd::u32x16::from_array([u32::MAX; 16]);
 
 // max value of p_to_bits is chosen so that an estimate doesn't overflow after
@@ -54,7 +56,10 @@ const PRC_BIT_TABLE_FROM_ERRORS_UNROLL_N: usize = 16; // must be up to 16.
 impl PrcBitTable {
     #[cfg(test)]
     pub fn zero() -> Self {
-        Self { p_to_bits_lo: ZEROS, p_to_bits_hi: ZEROS }
+        Self {
+            p_to_bits_lo: ZEROS,
+            p_to_bits_hi: ZEROS,
+        }
     }
 
     pub fn from_errors(errors: &[u32], offset: usize) -> Self {
@@ -62,8 +67,8 @@ impl PrcBitTable {
         debug_assert!(offset < (1 << 31));
         let offset_lo =
             simd::u32x16::splat(offset as u32) + simd::u32x16::splat(errors.len() as u32) * INDEX1;
-        let offset_hi =
-            simd::u32x16::splat(offset as u32) + simd::u32x16::splat(errors.len() as u32) * INDEX1_HI;
+        let offset_hi = simd::u32x16::splat(offset as u32)
+            + simd::u32x16::splat(errors.len() as u32) * INDEX1_HI;
         let mut p_to_bits_lo = ZEROS;
         let mut p_to_bits_hi = ZEROS;
 
@@ -91,7 +96,10 @@ impl PrcBitTable {
         p_to_bits_lo = p_to_bits_lo.simd_min(MAX_P_TO_BITS_VEC);
         p_to_bits_hi += offset_hi;
         p_to_bits_hi = p_to_bits_hi.simd_min(MAX_P_TO_BITS_VEC);
-        Self { p_to_bits_lo, p_to_bits_hi }
+        Self {
+            p_to_bits_lo,
+            p_to_bits_hi,
+        }
     }
 
     #[cfg(test)]
@@ -136,8 +144,10 @@ impl PrcBitTable {
     pub fn merge(&self, other: &Self, offset: usize) -> Self {
         let offset = simd::u32x16::splat(offset as u32);
         Self {
-            p_to_bits_lo: (self.p_to_bits_lo + other.p_to_bits_lo - offset).simd_min(MAX_P_TO_BITS_VEC),
-            p_to_bits_hi: (self.p_to_bits_hi + other.p_to_bits_hi - offset).simd_min(MAX_P_TO_BITS_VEC),
+            p_to_bits_lo: (self.p_to_bits_lo + other.p_to_bits_lo - offset)
+                .simd_min(MAX_P_TO_BITS_VEC),
+            p_to_bits_hi: (self.p_to_bits_hi + other.p_to_bits_hi - offset)
+                .simd_min(MAX_P_TO_BITS_VEC),
         }
     }
 }


### PR DESCRIPTION
  Implements 5-bit rice parameter coding (RICE2) for partitioned rice
  residuals. This fixes severely degraded compression for 24-bit audio
  where residuals frequently exceed what 4-bit parameters (max 14) can
  efficiently encode.

  Changes:
  - Raise MAX_RICE_PARAMETER from 14 to 30
  - Extend PrcBitTable to use two u32x16 SIMD vectors for params 0..30
  - Emit RICE2 method code when any partition needs parameter > 14
  - Update test expectations for the new parameter range

  Fixes #246

  - Output is binary identical to that coming from ffmpeg encoding to flac (but quicker)