### PR TITLE
Improvements to the benchmarking script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ profile.pb
 # artifacts used in bench_runner
 key.json
 .env
+src.tar.gz
+bench_runner/.testwav

--- a/bench_runner/Containerfile
+++ b/bench_runner/Containerfile
@@ -1,5 +1,7 @@
 FROM rust:1-slim-bookworm
 
+ARG REPO_DIGEST
+
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
      build-essential \
@@ -27,6 +29,10 @@ RUN curl -fsSL https://astral.sh/uv/install.sh | sh
 
 COPY runner_scripts/collect_host_info.sh /collect_host_info.sh
 COPY runner_scripts/run_all.sh /run_all.sh
+COPY src.tar.gz /src.tar.gz
+COPY .testwav /testwav
+
+ENV REPO_DIGEST=${REPO_DIGEST}
 
 # bash /run_all.sh | tee /bench_log.txt
 CMD ["bash", "/run_all.sh"]

--- a/bench_runner/README.md
+++ b/bench_runner/README.md
@@ -1,1 +1,8 @@
 # Benchmark runner
+
+## For local testing
+
+```
+podman build --platform linux/arm64  .
+podman run --rm -it [Digest]
+```

--- a/bench_runner/gce_run_job.sh
+++ b/bench_runner/gce_run_job.sh
@@ -19,13 +19,28 @@ EOF
 fi
 echo "Project: ${GCP_PROJECT}"
 
+pushd $(git rev-parse --show-toplevel)
+git archive --format=tgz --prefix=flacenc-rs/ -o bench_runner/src.tar.gz HEAD
+popd
+
 REPO_DIGEST="$(git rev-parse --short=7 HEAD)"
-podman build --platform=linux/amd64 -t "${GCP_REPOSITORY}/${GCP_PROJECT}/benchrunner/benchrunner:${REPO_DIGEST}" .
+
+## Download testwavs
+if [[ ! -d .testwav ]] ; then
+  export WIKIMEDIA_ROOT="https://upload.wikimedia.org/wikipedia/commons"
+  mkdir .testwav/
+  curl -sSL "${WIKIMEDIA_ROOT}/9/97/%22I_Love_You%2C_California%22%2C_performed_by_the_Prince%27s_Orchestra_in_1914_for_Columbia_Records.oga" | ffmpeg -i - .testwav/wikimedia.i_love_you_california.wav
+  curl -sSL "${WIKIMEDIA_ROOT}/b/bd/Drozerix_-_A_Winter_Kiss.wav" > .testwav/wikimedia.winter_kiss.wav 
+  curl -sSL "${WIKIMEDIA_ROOT}/7/7f/Jazz_Funk_no1_%28saxophone%29.flac" | ffmpeg -i - .testwav/wikimedia.jazz_funk_no1_sax.wav
+  curl -sSL "${WIKIMEDIA_ROOT}/5/5e/Albert_Roussel_-_Suite_en_Fa%2C_op.33_-_I._Pr%C3%A9lude.flac" | ffmpeg -i - .testwav/wikimedia.suite_en_fa_op_33_1.wav
+fi
+
+podman build --platform=linux/amd64 --build-arg "REPO_DIGEST=${REPO_DIGEST}" -t "${GCP_REPOSITORY}/${GCP_PROJECT}/benchrunner/benchrunner:${REPO_DIGEST}" .
 podman push "${GCP_REPOSITORY}/${GCP_PROJECT}/benchrunner/benchrunner:${REPO_DIGEST}"
 
 gcloud compute instances create-with-container benchrunner-vm \
   --zone "${GCP_ZONE}" \
-  --machine-type e2-standard-8 \
+  --machine-type c2-standard-8 \
   --boot-disk-size=50GB \
   --boot-disk-type=pd-balanced \
   --service-account "${GCP_SERVICE_ACCOUNT}" \

--- a/bench_runner/runner_scripts/collect_host_info.sh
+++ b/bench_runner/runner_scripts/collect_host_info.sh
@@ -63,6 +63,7 @@ cmd env | grep -Ev '(KEY|API|SECRET)'
 section "Git"
 cmd git rev-parse HEAD
 cmd git status --porcelain
+cmd echo "${REPO_DIGEST}"
 
 section "Rust"
 cmd rustup run stable rustc --version --verbose

--- a/bench_runner/runner_scripts/run_all.sh
+++ b/bench_runner/runner_scripts/run_all.sh
@@ -1,38 +1,21 @@
 #!/bin/sh
 set -eux
 
+export SRC_PATH="/src.tar.gz"
 export FLAC_VERSION="1.4.3"
 export FLAC_RELEASE_DIR="https://ftp.osuosl.org/pub/xiph/releases/flac"
 export PATH=$PATH:/root/.local/bin
-export WIKIMEDIA_ROOT="https://upload.wikimedia.org/wikipedia/commons"
 export REPORT_DIR="/report.$(date +%Y%m%d_%H%M%S)"
 export DEST_BUCKET="flacenc-rs-benchmark-results"
 export GCS_KEY_PATH="/secrets/gcs.json"
 
 mkdir "${REPORT_DIR}"
 
-git clone https://github.com/yotarok/flacenc-rs.git
+tar xvzf "${SRC_PATH}"
 cd flacenc-rs
-
-export HEAD_DIGEST="$(git rev-parse --short=7 HEAD)"
 
 ## Collect System Information
 bash /collect_host_info.sh | tee "${REPORT_DIR}/system_info.md"
-
-## Download testwavs
-
-mkdir testwav
-curl "${WIKIMEDIA_ROOT}/9/97/%22I_Love_You%2C_California%22%2C_performed_by_the_Prince%27s_Orchestra_in_1914_for_Columbia_Records.oga" \
-  | ffmpeg -i - testwav/wikimedia.i_love_you_california.wav
-
-curl "${WIKIMEDIA_ROOT}/b/bd/Drozerix_-_A_Winter_Kiss.wav" \
-  > testwav/wikimedia.winter_kiss.wav
-
-curl "${WIKIMEDIA_ROOT}/7/7f/Jazz_Funk_no1_%28saxophone%29.flac" \
-  | ffmpeg -i - testwav/wikimedia.jazz_funk_no1_sax.wav
-
-curl "${WIKIMEDIA_ROOT}/5/5e/Albert_Roussel_-_Suite_en_Fa%2C_op.33_-_I._Pr%C3%A9lude.flac" \
-  | ffmpeg -i - testwav/wikimedia.suite_en_fa_op_33_1.wav
 
 ## Build FLAC reference encoder
 
@@ -52,6 +35,7 @@ rustup run nightly cargo bench \
     --features "experimental,par,simd-nightly" -- \
     --skip tests:: | tee "${REPORT_DIR}/bench_results.nightly.txt"
 
+cp -r ../testwav ./
 
 ## Integration benchmarking
 
@@ -75,11 +59,11 @@ uv run --project pytools python ./pytools/reporter.py \
 
 ## Upload
 
-if [[ -f ${GCS_KEY_PATH} ]] ; then
+if [[ -f "${GCS_KEY_PATH}" ]] ; then
   gsutil \
     -o "Credentials:gs_service_key_file=${GCS_KEY_PATH}" \
-    cp -r "${REPORT_DIR}" "gs://${DEST_BUCKET}/${HEAD_DIGEST}/$(date +%Y%m%d_%H%M%S)"
+    cp -r "${REPORT_DIR}" "gs://${DEST_BUCKET}/${REPO_DIGEST}/$(date +%Y%m%d_%H%M%S)"
 else
   gsutil \
-    cp -r "${REPORT_DIR}" "gs://${DEST_BUCKET}/${HEAD_DIGEST}/$(date +%Y%m%d_%H%M%S)"
+    cp -r "${REPORT_DIR}" "gs://${DEST_BUCKET}/${REPO_DIGEST}/$(date +%Y%m%d_%H%M%S)"
 fi


### PR DESCRIPTION
1. the script can now run benchmark over non-pushed HEAD
2. the script now downloads test material locally and burns them in the docker image. this is important for avoiding errors due to wikipedia's request limit.
3. the script now uses "c2-standard-8" instead of "e2-standard-8" because "e2" is a mixture of AMD and Intel, whereas "c2" currently ensures the cpu family is "Intel Cascade Lake".